### PR TITLE
ftpserver: specify port range for data connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ type FileStream interface {
 
 // Settings define all the server settings
 type Settings struct {
-	Host           string // Host to receive connections on
-	Port           int    // Port to listen on
+	ListenHost     string // Host to receive connections on
+	ListenPort     int    // Port to listen on
+	PublicHost     string //Public IP to expose (only an IP address is accepted at this stage)
 	MaxConnections int    // Max number of connections to accept
-	MonitorOn      bool   // To activate the monitor
-	MonitorPort    int    // Port for the monitor to listen on
+	DataPortRange PortRange // Port range for data connections. Random one will be used if not specified
 }
 ```
 

--- a/server/driver.go
+++ b/server/driver.go
@@ -74,10 +74,18 @@ type FileStream interface {
 	io.Seeker
 }
 
+// PortRange is a range of ports
+type PortRange struct {
+	Start int // Range start
+	End   int // Range end
+}
+
 // Settings define all the server settings
 type Settings struct {
 	ListenHost     string // Host to receive connections on
 	ListenPort     int    // Port to listen on
 	PublicHost     string // Public IP to expose (only an IP address is accepted at this stage)
 	MaxConnections int    // Max number of connections to accept
+
+	DataPortRange *PortRange // Port Range for data connections. Random one will be used if not specified
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,10 +4,11 @@ package server
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/inconshreveable/log15.v2"
 	"net"
 	"sync"
 	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 var commandsMap map[string]func(*clientHandler)


### PR DESCRIPTION
Client Applications are now able to specify port ranges which to be used for the data connections. This option should be used when ftp server is limited to specific list of ports in isolated environments such as docker or any lxc container.

Fixes #3 