### PR TITLE
ftpserver: support active mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Note: this is a fork of [andrewarrow/paradise_ftp](https://github.com/andrewarro
  * TLS support
  * File download/upload resume support
  * Complete driver for all the above features
- * Passive socket connections (EPSV and PASV commands, no active connections)
+ * Passive socket connections (EPSV and PASV commands)
+ * Active socket connections (PORT command)
  * Small memory footprint
  * Only relies on the standard library except for logging which uses [log15](https://github.com/inconshreveable/log15)
  

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -4,11 +4,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"gopkg.in/inconshreveable/log15.v2"
 	"io"
 	"net"
 	"strings"
 	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 type clientHandler struct {

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ func init() {
 	commandsMap["TYPE"] = (*clientHandler).handleTYPE
 	commandsMap["PASV"] = (*clientHandler).handlePASV
 	commandsMap["EPSV"] = (*clientHandler).handlePASV
+	commandsMap["PORT"] = (*clientHandler).handlePORT
 	commandsMap["QUIT"] = (*clientHandler).handleQUIT
 
 	// TLS handling

--- a/server/transfer_active.go
+++ b/server/transfer_active.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+func (c *clientHandler) handlePORT() {
+	raddr := parseRemoteAddr(c.param)
+
+	c.writeMessage(200, "PORT command successful")
+
+	c.transfer = &activeTransferHandler{raddr: raddr}
+}
+
+// Active connection
+type activeTransferHandler struct {
+	// remote address of the client
+	raddr *net.TCPAddr
+
+	conn net.Conn
+}
+
+func (a *activeTransferHandler) Open() (net.Conn, error) {
+	laddr, _ := net.ResolveTCPAddr("tcp", ":20")
+	// TODO(mgenov): support dialing with timeout
+	// Issues:
+	//	https://github.com/golang/go/issues/3097
+	// 	https://github.com/golang/go/issues/4842
+	conn, err := net.DialTCP("tcp", laddr, a.raddr)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not establish active connection due: %v", err)
+	}
+
+	// keep connection as it will be closed by Close()
+	a.conn = conn
+
+	return a.conn, nil
+}
+
+// Close closes only if connection is established
+func (a *activeTransferHandler) Close() error {
+	if a.conn != nil {
+		return a.conn.Close()
+	}
+	return nil
+}
+
+// parseRemoteAddr parses remote address of the client from param. This address
+// is used for establishing a connection with the client.
+//
+// Param Format: 192,168,150,80,14,178
+// Host: 192.168.150.80
+// Port: (14 * 256) + 148
+func parseRemoteAddr(param string) *net.TCPAddr {
+	//TODO(mgenov): ensure that format of the params is valid
+	params := strings.Split(param, ",")
+	ip := strings.Join(params[0:4], ".")
+
+	p1, _ := strconv.Atoi(params[4])
+	p2, _ := strconv.Atoi(params[5])
+	port := (p1 * 256) + p2
+
+	addr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", ip, port))
+	return addr
+}


### PR DESCRIPTION
Added support for active mode where the client acts as an active part.
This change will support an old clients which are using PORT command for
establishing PORT.

Command: PORT 192,168,150,80,14,178

Flow:
```
FTP server's port 21 from anywhere (Client initiates connection)
FTP server's port 21 to ports > 1023 (Server responds to client's
control port)
FTP server's port 20 to ports > 1023 (Server initiates data connection
to client's data port)
FTP server's port 20 from ports > 1023 (Client sends ACKs to server's
data port)
```

Fixes #5