### PR TITLE
Added case insensitive handling parameters for OPTS command

### DIFF
--- a/server/handle_misc.go
+++ b/server/handle_misc.go
@@ -73,7 +73,7 @@ func (c *clientHandler) handleSTATServer() {
 
 func (c *clientHandler) handleOPTS() {
 	args := strings.SplitN(c.param, " ", 2)
-	if args[0] == "UTF8" {
+	if strings.ToUpper(args[0]) == "UTF8" {
 		c.writeMessage(200, "I'm in UTF8 only anyway")
 	} else {
 		c.writeMessage(500, "Don't know this option")


### PR DESCRIPTION
Some clients send parameters in lower case, for example Explorer.