### PR TITLE
Extending the clientcontext driver

### DIFF
--- a/.docker-create-upload.sh
+++ b/.docker-create-upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-version=$(go version|grep -Eo go[0-9\.]+)
+version=$(go version|grep -Eo go[0-9]\.[0-9])
 
 if [ "$version" != "go1.9" ]; then
     echo "Docker images are only generated for Go 1.9 and you have ${version}."
@@ -68,4 +68,5 @@ fi
 # Check the file listing is working fine
 curl -s ftp://test:test@localhost:2121/
 
-docker push ${DOCKER_REPO}
+# florent(2017-10-27): Docker hub is becoming dirty. Let's only keep the branches and tags
+docker push ${DOCKER_REPO}:${DOCKER_TAG}

--- a/sample/sample_driver.go
+++ b/sample/sample_driver.go
@@ -80,7 +80,7 @@ func (driver *MainDriver) GetTLSConfig() (*tls.Config, error) {
 func (driver *MainDriver) WelcomeUser(cc server.ClientContext) (string, error) {
 	cc.SetDebug(true)
 	// This will remain the official name for now
-	return fmt.Sprintf("Welcome on ftpserver, you're on dir %s", driver.BaseDir), nil
+	return fmt.Sprintf("Welcome on ftpserver, you're on dir %s, your ID is %d, your IP:port is %s", driver.BaseDir, cc.ID(), cc.RemoteAddr()), nil
 }
 
 // AuthUser authenticates the user and selects an handling driver

--- a/sample/sample_driver.go
+++ b/sample/sample_driver.go
@@ -18,7 +18,7 @@ import (
 	"github.com/naoina/toml"
 )
 
-// MainDriver defines a very basic serverftp driver
+// MainDriver defines a very basic ftpserver driver
 type MainDriver struct {
 	Logger       log.Logger  // Logger (probably shared with other components)
 	SettingsFile string      // Settings file
@@ -200,26 +200,25 @@ func (driver *MainDriver) GetSettings() *server.Settings {
 }
 
 // NewSampleDriver creates a sample driver
-// Note: This is not a mistake. Interface can be pointers. There seems to be a lot of confusion around this in the
-//       server_ftp original code.
-func NewSampleDriver() (*MainDriver, error) {
-	dir, err := ioutil.TempDir("", "ftpserver")
-	if err != nil {
-		return nil, fmt.Errorf("could not find a temporary dir, err: %v", err)
+func NewSampleDriver(dir string, settingsFile string) (*MainDriver, error) {
+	if dir == "" {
+		var err error
+		dir, err = ioutil.TempDir("", "ftpserver")
+		if err != nil {
+			return nil, fmt.Errorf("could not find a temporary dir, err: %v", err)
+		}
 	}
 
-	driver := &MainDriver{
+	drv := &MainDriver{
 		Logger:       log.NewNopLogger(),
-		SettingsFile: "sample/conf/settings.toml",
+		SettingsFile: settingsFile,
 		BaseDir:      dir,
 	}
 
-	// This is also a good time to create our dir
-	os.MkdirAll(driver.BaseDir, 0777)
-
-	return driver, nil
+	return drv, nil
 }
 
+// The virtual file is an example of how you can implement a purely virtual file
 type virtualFile struct {
 	content    []byte // Content of the file
 	readOffset int    // Reading offset

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -80,14 +80,9 @@ func (c *clientHandler) SetDebug(debug bool) {
 	c.debug = debug
 }
 
-// Conn provides access to the TCP connection
-func (c *clientHandler) Conn() net.Conn {
-	return c.conn
-}
-
-// Logger provides a go-kit logger
-func (c *clientHandler) Logger() log.Logger {
-	return c.logger
+// Conn provides access to the TCP connection's remote address
+func (c *clientHandler) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
 }
 
 func (c *clientHandler) end() {
@@ -108,7 +103,6 @@ func (c *clientHandler) HandleCommands() {
 
 	defer c.daddy.driver.UserLeft(c)
 
-	//fmt.Println(c.id, " Got client on: ", c.ip)
 	if msg, err := c.daddy.driver.WelcomeUser(c); err == nil {
 		c.writeMessage(220, msg)
 	} else {

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -80,6 +80,16 @@ func (c *clientHandler) SetDebug(debug bool) {
 	c.debug = debug
 }
 
+// Conn provides access to the TCP connection
+func (c *clientHandler) Conn() net.Conn {
+	return c.conn
+}
+
+// Logger provides a go-kit logger
+func (c *clientHandler) Logger() log.Logger {
+	return c.logger
+}
+
 func (c *clientHandler) end() {
 	if c.transfer != nil {
 		c.transfer.Close()

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -80,7 +80,7 @@ func (c *clientHandler) SetDebug(debug bool) {
 	c.debug = debug
 }
 
-// Conn provides access to the TCP connection's remote address
+// RemoteAddr returns the remote network address.
 func (c *clientHandler) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -14,7 +14,7 @@ import (
 )
 
 type clientHandler struct {
-	ID          uint32               // ID of the client
+	id          uint32               // ID of the client
 	daddy       *FtpServer           // Server on which the connection was accepted
 	driver      ClientHandlingDriver // Client handling driver
 	conn        net.Conn             // TCP connection
@@ -43,7 +43,7 @@ func (server *FtpServer) newClientHandler(connection net.Conn) *clientHandler {
 	p := &clientHandler{
 		daddy:       server,
 		conn:        connection,
-		ID:          id,
+		id:          id,
 		writer:      bufio.NewWriter(connection),
 		reader:      bufio.NewReader(connection),
 		connectedAt: time.Now().UTC(),
@@ -78,6 +78,11 @@ func (c *clientHandler) Debug() bool {
 // SetDebug changes the debug flag
 func (c *clientHandler) SetDebug(debug bool) {
 	c.debug = debug
+}
+
+// ID provides the client's ID
+func (c *clientHandler) ID() uint32 {
+	return c.id
 }
 
 // RemoteAddr returns the remote network address.

--- a/server/driver.go
+++ b/server/driver.go
@@ -69,6 +69,9 @@ type ClientContext interface {
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
 
+	// Client's ID on the server
+	ID() uint32
+
 	// Client's address
 	RemoteAddr() net.Addr
 }

--- a/server/driver.go
+++ b/server/driver.go
@@ -3,7 +3,10 @@ package server
 import (
 	"crypto/tls"
 	"io"
+	"net"
 	"os"
+
+	"github.com/go-kit/kit/log"
 )
 
 // This file is the driver part of the server. It must be implemented by anyone wanting to use the server.
@@ -67,6 +70,12 @@ type ClientContext interface {
 
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
+
+	// TCP Connection
+	Conn() net.Conn
+
+	// Logger
+	Logger() log.Logger
 }
 
 // FileStream is a read or write closeable stream

--- a/server/driver.go
+++ b/server/driver.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net"
 	"os"
-
-	"github.com/go-kit/kit/log"
 )
 
 // This file is the driver part of the server. It must be implemented by anyone wanting to use the server.
@@ -71,11 +69,8 @@ type ClientContext interface {
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
 
-	// TCP Connection
-	Conn() net.Conn
-
-	// Logger
-	Logger() log.Logger
+	// Client's address
+	RemoteAddr() net.Addr
 }
 
 // FileStream is a read or write closeable stream

--- a/server/server.go
+++ b/server/server.go
@@ -187,7 +187,7 @@ func (server *FtpServer) clientArrival(c *clientHandler) error {
 	server.connectionsMutex.Lock()
 	defer server.connectionsMutex.Unlock()
 
-	server.connectionsByID[c.ID] = c
+	server.connectionsByID[c.id] = c
 	nb := len(server.connectionsByID)
 
 	level.Info(c.logger).Log(logKeyMsg, "FTP Client connected", logKeyAction, "ftp.connected", "clientIp", c.conn.RemoteAddr(), "total", nb)
@@ -204,7 +204,7 @@ func (server *FtpServer) clientDeparture(c *clientHandler) {
 	server.connectionsMutex.Lock()
 	defer server.connectionsMutex.Unlock()
 
-	delete(server.connectionsByID, c.ID)
+	delete(server.connectionsByID, c.id)
 
 	level.Info(c.logger).Log(logKeyMsg, "FTP Client disconnected", logKeyAction, "ftp.disconnected", "clientIp", c.conn.RemoteAddr(), "total", len(server.connectionsByID))
 }


### PR DESCRIPTION
Someone (Artem) contacted me by email and reported two things:
- Client handling driver didn't allow to get the client's IP address
- The logging part isn't clear enough

This PR intends to fix that