### PR TITLE
Improving the sample server

### DIFF
--- a/.docker-create-upload.sh
+++ b/.docker-create-upload.sh
@@ -50,7 +50,7 @@ done
 
 # Checking that by default the localpath is the "/data" directory
 path=$(curl -s ftp://test:test@localhost:2121/virtual/localpath.txt)
-if [ "${path}" != "/data" ]; then
+if [ "${path}" != "/data/shared" ]; then
     echo "The path is wrong: ${path}"
     exit 1
 fi

--- a/sample/conf/settings.toml
+++ b/sample/conf/settings.toml
@@ -2,6 +2,7 @@
 #
 # These are all the config parameters with their default values. If not present,
 
+[server]
 # Address to listen on
 # listen_host = "0.0.0.0"
 
@@ -18,6 +19,22 @@
 # [dataPortRange]
 # start = 2122
 # end = 2200
-[dataPortRange]
+
+[server.dataPortRange]
 start = 2122
 end = 2200
+
+[[users]]
+user="fclairamb"
+pass="floflo"
+dir="shared"
+
+[[users]]
+user="test"
+pass="test"
+dir="shared"
+
+[[users]]
+user="mcardon"
+pass="marmar"
+dir="marie"

--- a/server/driver.go
+++ b/server/driver.go
@@ -12,7 +12,7 @@ import (
 // MainDriver handles the authentication and ClientHandlingDriver selection
 type MainDriver interface {
 	// GetSettings returns some general settings around the server setup
-	GetSettings() *Settings
+	GetSettings() (*Settings, error)
 
 	// WelcomeUser is called to send the very first welcome message
 	WelcomeUser(cc ClientContext) (string, error)

--- a/server/server.go
+++ b/server/server.go
@@ -4,9 +4,8 @@ package server
 import (
 	"fmt"
 	"net"
-	"time"
-
 	"sync/atomic"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -92,8 +91,13 @@ type FtpServer struct {
 	driver        MainDriver   // Driver to handle the client authentication and the file access driver selection
 }
 
-func (server *FtpServer) loadSettings() {
-	s := server.driver.GetSettings()
+func (server *FtpServer) loadSettings() error {
+	s, err := server.driver.GetSettings()
+
+	if err != nil {
+		return err
+	}
+
 	if s.ListenHost == "" {
 		s.ListenHost = "0.0.0.0"
 	}
@@ -109,13 +113,18 @@ func (server *FtpServer) loadSettings() {
 		s.MaxConnections = 10000
 	}
 	server.Settings = s
+
+	return nil
 }
 
 // Listen starts the listening
 // It's not a blocking call
 func (server *FtpServer) Listen() error {
-	server.loadSettings()
-	var err error
+	err := server.loadSettings()
+
+	if err != nil {
+		return fmt.Errorf("could not load settings: %v", err)
+	}
 
 	server.Listener, err = net.Listen(
 		"tcp",

--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -63,8 +63,8 @@ func (driver *ServerDriver) UserLeft(cc server.ClientContext) {
 }
 
 // GetSettings fetches the basic server settings
-func (driver *ServerDriver) GetSettings() *server.Settings {
-	return &server.Settings{ListenHost: "127.0.0.1", ListenPort: -1, DisableMLSD: driver.DisableMLSD}
+func (driver *ServerDriver) GetSettings() (*server.Settings, error) {
+	return &server.Settings{ListenHost: "127.0.0.1", ListenPort: -1, DisableMLSD: driver.DisableMLSD}, nil
 }
 
 // GetTLSConfig fetches the TLS config


### PR DESCRIPTION
After reading [@ninehills's fork](https://github.com/ninehills/ftpserver/), I realized some of the shortcuts I took in the sample driver implementation were confusing. That made @ninehills modify the `server.Settings` structure to allow to define a user/pass.
This clarifies it by separating the sample driver and server settings and by showing how an authentication mechanism could be implemented.

# Changes
- Improving the sample server by providing a proper authentication implementation
- Changing the MainDriver::GetSettings to be able to return an error