### PR TITLE
API changes

### DIFF
--- a/server/driver.go
+++ b/server/driver.go
@@ -90,10 +90,9 @@ type PortRange struct {
 	End   int // Range end
 }
 
-// Settings define all the server settings
+// Settings defines all the server settings
 type Settings struct {
-	ListenHost                string     // Host to receive connections on
-	ListenPort                int        // Port to listen on
+	ListenAddr                string     // Listening address
 	PublicHost                string     // Public IP to expose (only an IP address is accepted at this stage)
 	MaxConnections            int        // Max number of connections to accept
 	DataPortRange             *PortRange // Port Range for data connections. Random one will be used if not specified

--- a/server/handle_dirs.go
+++ b/server/handle_dirs.go
@@ -91,7 +91,7 @@ func (c *clientHandler) handleLIST() {
 }
 
 func (c *clientHandler) handleMLSD() {
-	if c.daddy.Settings.DisableMLSD {
+	if c.daddy.settings.DisableMLSD {
 		c.writeMessage(500, "MLSD has been disabled")
 		return
 	}

--- a/server/handle_misc.go
+++ b/server/handle_misc.go
@@ -59,8 +59,8 @@ func (c *clientHandler) handleSTATServer() {
 	duration := time.Now().UTC().Sub(c.connectedAt)
 	duration -= duration % time.Second
 	c.writeLine(fmt.Sprintf(
-		"Connected to %s:%d from %s for %s",
-		c.daddy.Settings.ListenHost, c.daddy.Settings.ListenPort,
+		"Connected to %s from %s for %s",
+		c.daddy.settings.ListenAddr,
 		c.conn.RemoteAddr(),
 		duration,
 	))
@@ -97,7 +97,7 @@ func (c *clientHandler) handleFEAT() {
 		"REST STREAM",
 	}
 
-	if !c.daddy.Settings.DisableMLSD {
+	if !c.daddy.settings.DisableMLSD {
 		features = append(features, "MLSD")
 	}
 

--- a/server/transfer_active.go
+++ b/server/transfer_active.go
@@ -18,7 +18,7 @@ func (c *clientHandler) handlePORT() {
 
 	c.writeMessage(200, "PORT command successful")
 
-	c.transfer = &activeTransferHandler{raddr: raddr, nonStandardPort: c.daddy.Settings.NonStandardActiveDataPort}
+	c.transfer = &activeTransferHandler{raddr: raddr, nonStandardPort: c.daddy.settings.NonStandardActiveDataPort}
 }
 
 // Active connection

--- a/server/transfer_pasv.go
+++ b/server/transfer_pasv.go
@@ -33,7 +33,7 @@ func (c *clientHandler) handlePASV() {
 	var tcpListener *net.TCPListener
 	var err error
 
-	portRange := c.daddy.Settings.DataPortRange
+	portRange := c.daddy.settings.DataPortRange
 
 	if portRange != nil {
 		for start := portRange.Start; start < portRange.End; start++ {
@@ -82,7 +82,7 @@ func (c *clientHandler) handlePASV() {
 		p1 := p.Port / 256
 		p2 := p.Port - (p1 * 256)
 		// Provide our external IP address so the ftp client can connect back to us
-		ip := c.daddy.Settings.PublicHost
+		ip := c.daddy.settings.PublicHost
 
 		// If we don't have an IP address, we can take the one that was used for the current connection
 		if ip == "" {

--- a/tests/client_handler_test.go
+++ b/tests/client_handler_test.go
@@ -21,7 +21,7 @@ func TestConcurrency(t *testing.T) {
 			var err error
 			var ftp *goftp.FTP
 
-			if ftp, err = goftp.Connect(s.Listener.Addr().String()); err != nil {
+			if ftp, err = goftp.Connect(s.Addr()); err != nil {
 				panic(err)
 			}
 			defer ftp.Close()

--- a/tests/handle_auth_test.go
+++ b/tests/handle_auth_test.go
@@ -13,7 +13,7 @@ func TestLoginSuccess(t *testing.T) {
 	var err error
 	var ftp *goftp.FTP
 
-	if ftp, err = goftp.Connect(s.Listener.Addr().String()); err != nil {
+	if ftp, err = goftp.Connect(s.Addr()); err != nil {
 		t.Fatal("Couldn't connect", err)
 	}
 	defer ftp.Quit()
@@ -46,7 +46,7 @@ func TestLoginFailure(t *testing.T) {
 	var err error
 	var ftp *goftp.FTP
 
-	if ftp, err = goftp.Connect(s.Listener.Addr().String()); err != nil {
+	if ftp, err = goftp.Connect(s.Addr()); err != nil {
 		t.Fatal("Couldn't connect:", err)
 	}
 

--- a/tests/handle_dirs_test.go
+++ b/tests/handle_dirs_test.go
@@ -4,18 +4,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fclairamb/ftpserver/server"
 	"gopkg.in/dutchcoders/goftp.v1"
 )
 
 // TestDirAccess relies on LIST of files listing
 func TestDirListing(t *testing.T) {
-	s := NewTestServerWithDriver(&ServerDriver{Debug: true, DisableMLSD: true})
+	s := NewTestServerWithDriver(&ServerDriver{Debug: true, Settings: &server.Settings{DisableMLSD: true}})
 	defer s.Stop()
 
 	var connErr error
 	var ftp *goftp.FTP
 
-	if ftp, connErr = goftp.Connect(s.Listener.Addr().String()); connErr != nil {
+	if ftp, connErr = goftp.Connect(s.Addr()); connErr != nil {
 		t.Fatal("Couldn't connect", connErr)
 	}
 	defer ftp.Quit()
@@ -61,7 +62,7 @@ func TestDirHandling(t *testing.T) {
 	var connErr error
 	var ftp *goftp.FTP
 
-	if ftp, connErr = goftp.Connect(s.Listener.Addr().String()); connErr != nil {
+	if ftp, connErr = goftp.Connect(s.Addr()); connErr != nil {
 		t.Fatal("Couldn't connect", connErr)
 	}
 	defer ftp.Quit()
@@ -106,7 +107,7 @@ func TestDirListingWithSpace(t *testing.T) {
 	var ftp *goftp.FTP
 	const debug = true
 
-	if ftp, connErr = goftp.Connect(s.Listener.Addr().String()); connErr != nil {
+	if ftp, connErr = goftp.Connect(s.Addr()); connErr != nil {
 		t.Fatal("Couldn't connect", connErr)
 	}
 	defer ftp.Quit()

--- a/tests/misc_commands_test.go
+++ b/tests/misc_commands_test.go
@@ -18,7 +18,7 @@ func TestSiteCommand(t *testing.T) {
 	var err error
 	var c *goftp.Client
 
-	if c, err = goftp.DialConfig(conf, s.Listener.Addr().String()); err != nil {
+	if c, err = goftp.DialConfig(conf, s.Addr()); err != nil {
 		t.Fatal("Couldn't connect", err)
 	}
 	defer c.Close()

--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -16,6 +16,14 @@ func NewTestServer(debug bool) *server.FtpServer {
 
 // NewTestServerWithDriver provides a server instantiated with some settings
 func NewTestServerWithDriver(driver *ServerDriver) *server.FtpServer {
+	if driver.Settings == nil {
+		driver.Settings = &server.Settings{}
+	}
+
+	if driver.Settings.ListenAddr == "" {
+		driver.Settings.ListenAddr = "127.0.0.1:0"
+	}
+
 	s := server.NewFtpServer(driver)
 	if err := s.Listen(); err != nil {
 		return nil
@@ -26,8 +34,8 @@ func NewTestServerWithDriver(driver *ServerDriver) *server.FtpServer {
 
 // ServerDriver defines a minimal serverftp server driver
 type ServerDriver struct {
-	Debug       bool // To display connection logs information
-	DisableMLSD bool // Disable MLSD
+	Debug    bool             // To display connection logs information
+	Settings *server.Settings // Settings
 }
 
 // ClientDriver defines a minimal serverftp client driver
@@ -64,7 +72,7 @@ func (driver *ServerDriver) UserLeft(cc server.ClientContext) {
 
 // GetSettings fetches the basic server settings
 func (driver *ServerDriver) GetSettings() (*server.Settings, error) {
-	return &server.Settings{ListenHost: "127.0.0.1", ListenPort: -1, DisableMLSD: driver.DisableMLSD}, nil
+	return driver.Settings, nil
 }
 
 // GetTLSConfig fetches the TLS config

--- a/tests/transfer_test.go
+++ b/tests/transfer_test.go
@@ -98,8 +98,7 @@ func ftpDelete(t *testing.T, ftp *goftp.Client, filename string) {
 
 // TestTransfer validates the upload of file in both active and passive mode
 func TestTransfer(t *testing.T) {
-	s := NewTestServer(true)
-	s.Settings.NonStandardActiveDataPort = true
+	s := NewTestServerWithDriver(&ServerDriver{Debug: true, Settings: &server.Settings{NonStandardActiveDataPort: true}})
 	defer s.Stop()
 
 	testTransferOnConnection(t, s, false)
@@ -116,7 +115,7 @@ func testTransferOnConnection(t *testing.T, server *server.FtpServer, active boo
 	var err error
 	var c *goftp.Client
 
-	if c, err = goftp.DialConfig(conf, server.Listener.Addr().String()); err != nil {
+	if c, err = goftp.DialConfig(conf, server.Addr()); err != nil {
 		t.Fatal("Couldn't connect", err)
 	}
 	defer c.Close()
@@ -152,7 +151,7 @@ func TestFailedTransfer(t *testing.T) {
 	var err error
 	var c *goftp.Client
 
-	if c, err = goftp.DialConfig(conf, s.Listener.Addr().String()); err != nil {
+	if c, err = goftp.DialConfig(conf, s.Addr()); err != nil {
 		t.Fatal("Couldn't connect", err)
 	}
 	defer c.Close()


### PR DESCRIPTION
... to get closer to how the `net.http.Server` package works.

* We're not exporting the `net.Listener` anymore
* We're not exporting the `Settings` anymore
* We're not saving and exporting the `StartTime` anymore
* We're expecting a `ListenAddr` instead of a `ListenHost` and `ListenPort`
* We're exporting the listening address like the `net.http.Server` package does
* Tests have been slightly changed to use the new API