### PR TITLE
External client ID setter and getter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ type ClientContext interface {
 
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
+
+    // SetID changes current connection external identifier
+    SetID(id interface{})
+
+    // Returns external client's ID
+    ID() interface{}
+
+    // Client's address
+    RemoteAddr() net.Addr
 }
 
 // FileStream is a read or write closeable stream

--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ type ClientContext interface {
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
 
-    // SetID changes current connection external identifier
-    SetID(id interface{})
+	// SetID changes current connection external identifier
+    	SetID(id interface{})
 
-    // Returns external client's ID
-    ID() interface{}
+	// Returns external client's ID
+	ID() interface{}
 
-    // Client's address
-    RemoteAddr() net.Addr
+	// Client's address
+	RemoteAddr() net.Addr
 }
 
 // FileStream is a read or write closeable stream

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ type ClientContext interface {
 	Debug() bool
 
 	// SetID changes current connection external identifier
-  SetID(id interface{})
+	SetID(id interface{})
 
 	// Returns external client's ID
 	ID() interface{}

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -14,7 +14,8 @@ import (
 )
 
 type clientHandler struct {
-	id          uint32               // ID of the client
+	id          uint32               // Internal ID of the client
+	extID       interface{}          // External ID of the client
 	daddy       *FtpServer           // Server on which the connection was accepted
 	driver      ClientHandlingDriver // Client handling driver
 	conn        net.Conn             // TCP connection
@@ -76,9 +77,14 @@ func (c *clientHandler) SetDebug(debug bool) {
 	c.debug = debug
 }
 
-// ID provides the client's ID
-func (c *clientHandler) ID() uint32 {
-	return c.id
+// SetID changes current connection external identifier
+func (c *clientHandler) SetID(id interface{}) {
+	c.extID = id
+}
+
+// ID provides the external client's ID
+func (c *clientHandler) ID() interface{} {
+	return c.extID
 }
 
 // RemoteAddr returns the remote network address.

--- a/server/driver.go
+++ b/server/driver.go
@@ -69,8 +69,11 @@ type ClientContext interface {
 	// Debug returns the current debugging status of this connection commands
 	Debug() bool
 
-	// Client's ID on the server
-	ID() uint32
+	// SetID changes current connection external identifier
+	SetID(id interface{})
+
+	// Returns external client's ID
+	ID() interface{}
 
 	// Client's address
 	RemoteAddr() net.Addr


### PR DESCRIPTION
As far as we talking about ID method, i think it's true way - provide to users set their own external identifiers for client. So i implemented methods `SetID(id interface{})` and `ID() interface{}` to provide them such facility. Take a glance and let's discuss that.