### PR TITLE
fixed concurrent access to connection by adding sync.RWMutex

### DIFF
--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -18,7 +18,7 @@ type clientHandler struct {
 	id          uint32               // ID of the client
 	daddy       *FtpServer           // Server on which the connection was accepted
 	driver      ClientHandlingDriver // Client handling driver
-	connMu sync.RWMutex
+	connMu      sync.RWMutex         // mutex for TCP connection
 	conn        net.Conn             // TCP connection
 	writer      *bufio.Writer        // Writer on the TCP connection
 	reader      *bufio.Reader        // Reader on the TCP connection

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"sync"
 )
 
 type clientHandler struct {
 	id          uint32               // ID of the client
 	daddy       *FtpServer           // Server on which the connection was accepted
 	driver      ClientHandlingDriver // Client handling driver
+	connMu sync.RWMutex
 	conn        net.Conn             // TCP connection
 	writer      *bufio.Writer        // Writer on the TCP connection
 	reader      *bufio.Reader        // Reader on the TCP connection

--- a/server/server.go
+++ b/server/server.go
@@ -194,7 +194,9 @@ func (server *FtpServer) receiveConnection(conn net.Conn) error {
 	c := server.newClientHandler(conn, id)
 	go c.HandleCommands()
 
+	c.connMu.RLock()
 	level.Info(c.logger).Log(logKeyMsg, "FTP Client connected", logKeyAction, "ftp.connected", "clientIp", c.conn.RemoteAddr(), "total", nb)
+	c.connMu.RUnlock()
 
 	return nil
 }
@@ -211,5 +213,7 @@ func (server *FtpServer) clientArrival(c *clientHandler) error {
 // clientDeparture
 func (server *FtpServer) clientDeparture(c *clientHandler) {
 	nb := int(atomic.AddInt32(&server.clientsNb, -1))
+	c.connMu.RLock()
 	level.Info(c.logger).Log(logKeyMsg, "FTP Client disconnected", logKeyAction, "ftp.disconnected", "clientIp", c.conn.RemoteAddr(), "total", nb)
+	c.connMu.RUnlock()
 }

--- a/server/transfer_pasv.go
+++ b/server/transfer_pasv.go
@@ -86,7 +86,10 @@ func (c *clientHandler) handlePASV() {
 
 		// If we don't have an IP address, we can take the one that was used for the current connection
 		if ip == "" {
+			c.connMu.RLock()
 			ip = strings.Split(c.conn.LocalAddr().String(), ":")[0]
+			c.connMu.RUnlock()
+			
 		}
 
 		quads := strings.Split(ip, ".")


### PR DESCRIPTION
In concurrent application which was built with -race flag i've got race condition warning:
there were a write into clientHandler's connection  `c.conn` and simultanious reading `c.conn.RemoteAddr()`.