### PR TITLE
Remove the counting of connections

### DIFF
--- a/sample/conf/settings.toml
+++ b/sample/conf/settings.toml
@@ -2,6 +2,10 @@
 #
 # These are all the config parameters with their default values. If not present,
 
+# Max number of control connections to accept
+# max_connections = 0
+max_connections = 10
+
 [server]
 # Address to listen on
 # listen_host = "0.0.0.0"
@@ -11,9 +15,6 @@
 
 # Public host to expose in the passive connection
 # public_host = ""
-
-# Max number of connections to accept
-# max_connections = 0
 
 # Data port range from 10000 to 15000
 # [dataPortRange]

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -87,6 +87,8 @@ func (c *clientHandler) RemoteAddr() net.Addr {
 }
 
 func (c *clientHandler) end() {
+	c.daddy.driver.UserLeft(c)
+	c.daddy.clientDeparture(c)
 	if c.transfer != nil {
 		c.transfer.Close()
 	}
@@ -94,16 +96,7 @@ func (c *clientHandler) end() {
 
 // HandleCommands reads the stream of commands
 func (c *clientHandler) HandleCommands() {
-	defer c.daddy.clientDeparture(c)
 	defer c.end()
-
-	if err := c.daddy.clientArrival(c); err != nil {
-		c.writeMessage(500, "Can't accept you - "+err.Error())
-		c.conn.Close()
-		return
-	}
-
-	defer c.daddy.driver.UserLeft(c)
 
 	if msg, err := c.daddy.driver.WelcomeUser(c); err == nil {
 		c.writeMessage(220, msg)

--- a/server/driver.go
+++ b/server/driver.go
@@ -94,7 +94,6 @@ type PortRange struct {
 type Settings struct {
 	ListenAddr                string     // Listening address
 	PublicHost                string     // Public IP to expose (only an IP address is accepted at this stage)
-	MaxConnections            int        // Max number of connections to accept
 	DataPortRange             *PortRange // Port Range for data connections. Random one will be used if not specified
 	DisableMLSD               bool       // Disable MLSD support
 	NonStandardActiveDataPort bool       // Allow to use a non-standard active data port

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ package server
 import (
 	"fmt"
 	"net"
-	"sync/atomic"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -85,7 +84,6 @@ type FtpServer struct {
 	settings      *Settings    // General settings
 	listener      net.Listener // listener used to receive files
 	clientCounter uint32       // Clients counter
-	clientsNb     int32        // Clients number
 	driver        MainDriver   // Driver to handle the client authentication and the file access driver selection
 }
 
@@ -98,10 +96,6 @@ func (server *FtpServer) loadSettings() error {
 
 	if s.ListenAddr == "" {
 		s.ListenAddr = "0.0.0.0:2121"
-	}
-
-	if s.MaxConnections == 0 {
-		s.MaxConnections = 10000
 	}
 
 	server.settings = s
@@ -144,7 +138,7 @@ func (server *FtpServer) Serve() {
 			break
 		}
 
-		server.receiveConnection(connection)
+		server.clientArrival(connection)
 	}
 }
 
@@ -187,29 +181,19 @@ func (server *FtpServer) Stop() {
 }
 
 // When a client connects, the server could refuse the connection
-func (server *FtpServer) receiveConnection(conn net.Conn) error {
-	nb := int(atomic.AddInt32(&server.clientsNb, 1))
-	id := atomic.AddUint32(&server.clientCounter, 1)
+func (server *FtpServer) clientArrival(conn net.Conn) error {
+	server.clientCounter++
+	id := server.clientCounter
 
 	c := server.newClientHandler(conn, id)
 	go c.HandleCommands()
 
-	level.Info(c.logger).Log(logKeyMsg, "FTP Client connected", logKeyAction, "ftp.connected", "clientIp", c.conn.RemoteAddr(), "total", nb)
-
-	return nil
-}
-
-// clientArrival does last minute checks after the client has arrived
-func (server *FtpServer) clientArrival(c *clientHandler) error {
-	if int(atomic.LoadInt32(&server.clientsNb)) > server.settings.MaxConnections {
-		return fmt.Errorf("too many clients %d > %d", server.clientsNb, server.settings.MaxConnections)
-	}
+	level.Info(c.logger).Log(logKeyMsg, "FTP Client connected", logKeyAction, "ftp.connected", "clientIp", c.conn.RemoteAddr())
 
 	return nil
 }
 
 // clientDeparture
 func (server *FtpServer) clientDeparture(c *clientHandler) {
-	nb := int(atomic.AddInt32(&server.clientsNb, -1))
-	level.Info(c.logger).Log(logKeyMsg, "FTP Client disconnected", logKeyAction, "ftp.disconnected", "clientIp", c.conn.RemoteAddr(), "total", nb)
+	level.Info(c.logger).Log(logKeyMsg, "FTP Client disconnected", logKeyAction, "ftp.disconnected", "clientIp", c.conn.RemoteAddr())
 }


### PR DESCRIPTION
# Goal
I'd like to remove everything that is not strictly necessary to implement a FTP server. The check around the maximum number of connections, if necessary, should be done on the server implementation itself.

# Changes
- Removed all codes that counts the number of connections. This allowed to remove the last reference to the sync package.
- Implemented this part on the sample driver code itself