### PR TITLE
Issue #58: Idle timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,7 +12,6 @@ import (
 	"github.com/fclairamb/ftpserver/server"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"io/ioutil"
 )
 
 var (
@@ -116,6 +116,9 @@ max_connections = 10
 
 # Public host to expose in the passive connection
 # public_host = ""
+
+# Idle timeout time
+# idle_timeout = 900
 
 # Data port range from 10000 to 15000
 # [dataPortRange]

--- a/sample/sample_driver.go
+++ b/sample/sample_driver.go
@@ -19,11 +19,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
+
 	"github.com/fclairamb/ftpserver/server"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/naoina/toml"
-	"math/big"
 )
 
 // MainDriver defines a very basic ftpserver driver

--- a/server/client_handler.go
+++ b/server/client_handler.go
@@ -4,11 +4,10 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
-
-	"io"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"

--- a/server/driver.go
+++ b/server/driver.go
@@ -106,4 +106,5 @@ type Settings struct {
 	DataPortRange             *PortRange       // Port Range for data connections. Random one will be used if not specified
 	DisableMLSD               bool             // Disable MLSD support
 	NonStandardActiveDataPort bool             // Allow to use a non-standard active data port
+	IdleTimeout               int              // Maximum inactivity time before disconnecting (#58)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -98,6 +98,11 @@ func (server *FtpServer) loadSettings() error {
 		s.ListenAddr = "0.0.0.0:2121"
 	}
 
+	// florent(2018-01-14): #58: IDLE timeout: Default idle timeout will be set at 900 seconds
+	if s.IdleTimeout == 0 {
+		s.IdleTimeout = 900
+	}
+
 	server.settings = s
 
 	return nil

--- a/tests/misc_commands_test.go
+++ b/tests/misc_commands_test.go
@@ -78,7 +78,7 @@ func TestIdleTimeout(t *testing.T) {
 
 	time.Sleep(time.Second * 3) // > 2s : Timeout
 
-	if _, _, err := raw.SendCommand("NOOP"); err == nil {
+	if rc, _, err := raw.SendCommand("NOOP"); err != nil || rc != 421 {
 		t.Fatal("Command should have failed !")
 	}
 }

--- a/tests/misc_commands_test.go
+++ b/tests/misc_commands_test.go
@@ -3,6 +3,9 @@ package tests
 import (
 	"testing"
 
+	"time"
+
+	"github.com/fclairamb/ftpserver/server"
 	"github.com/secsy/goftp"
 )
 
@@ -38,5 +41,44 @@ func TestSiteCommand(t *testing.T) {
 		if response != "Not understood SITE subcommand" {
 			t.Fatal("Are we supporting it now ?", response)
 		}
+	}
+}
+
+// florent(2018-01-14): #58: IDLE timeout: Testing timeout
+func TestIdleTimeout(t *testing.T) {
+	s := NewTestServerWithDriver(&ServerDriver{Debug: true, Settings: &server.Settings{IdleTimeout: 2}})
+	defer s.Stop()
+
+	conf := goftp.Config{
+		User:     "test",
+		Password: "test",
+	}
+
+	var err error
+	var c *goftp.Client
+
+	if c, err = goftp.DialConfig(conf, s.Addr()); err != nil {
+		t.Fatal("Couldn't connect", err)
+	}
+	defer c.Close()
+
+	var raw goftp.RawConn
+
+	if raw, err = c.OpenRawConn(); err != nil {
+		t.Fatal("Couldn't open raw connection")
+	}
+
+	time.Sleep(time.Second * 1) // < 2s : OK
+
+	if rc, _, err := raw.SendCommand("NOOP"); err != nil {
+		t.Fatal("Command not accepted", err)
+	} else if rc != 200 {
+		t.Fatalf("Bad response: %d", rc)
+	}
+
+	time.Sleep(time.Second * 3) // > 2s : Timeout
+
+	if _, _, err := raw.SendCommand("NOOP"); err == nil {
+		t.Fatal("Command should have failed !")
 	}
 }

--- a/tests/misc_commands_test.go
+++ b/tests/misc_commands_test.go
@@ -70,10 +70,8 @@ func TestIdleTimeout(t *testing.T) {
 
 	time.Sleep(time.Second * 1) // < 2s : OK
 
-	if rc, _, err := raw.SendCommand("NOOP"); err != nil {
-		t.Fatal("Command not accepted", err)
-	} else if rc != 200 {
-		t.Fatalf("Bad response: %d", rc)
+	if rc, _, err := raw.SendCommand("NOOP"); err != nil || rc != 200 {
+		t.Fatal("Command not accepted", rc, err)
 	}
 
 	time.Sleep(time.Second * 3) // > 2s : Timeout


### PR DESCRIPTION
This PR brings support for command timeout as requested in issue #58 made by @worddevfr.

By default the idle timeout will be set to 900 seconds.