### PR TITLE
make a failing closer return the error to the client

### DIFF
--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -19,29 +19,39 @@ func (c *clientHandler) handleAPPE() {
 
 // Handles both the "STOR" and "APPE" commands
 func (c *clientHandler) handleStoreAndAppend(append bool) {
+	if err := c.storeOrAppend(append); err != nil {
+		c.writeMessage(550, err.Error())
+	}
+}
+
+func (c *clientHandler) storeOrAppend(append bool) (err error) {
 	file, err := c.openFile(c.absPath(c.param), append)
-
 	if err != nil {
-		c.writeMessage(550, "Could not open file: "+err.Error())
-		return
+		return fmt.Errorf("Could not open file: %s", err)
 	}
 
-	if tr, err := c.TransferOpen(); err == nil {
-		defer c.TransferClose()
-
-		_, err := c.storeOrAppend(tr, file)
-		if err != nil && err != io.EOF {
-			c.writeMessage(550, err.Error())
-			file.Close()
-			return
+	defer func() {
+		if errClose := file.Close(); errClose != nil && err == nil {
+			err = errClose
 		}
+	}()
 
-		if err := file.Close(); err != nil {
-			c.writeMessage(550, err.Error())
-		}
-	} else {
-		c.writeMessage(550, "Could not open transfer: "+err.Error())
+	tr, err := c.TransferOpen()
+	if err != nil {
+		return fmt.Errorf("Could not open transfer: %s", err)
 	}
+	defer c.TransferClose()
+
+	if c.ctxRest != 0 {
+		file.Seek(c.ctxRest, 0)
+		c.ctxRest = 0
+	}
+
+	if _, err := io.Copy(file, tr); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
 }
 
 func (c *clientHandler) openFile(path string, append bool) (FileStream, error) {
@@ -100,15 +110,6 @@ func (c *clientHandler) handleCHMOD(params string) {
 	}
 
 	c.writeMessage(200, "SITE CHMOD command successful")
-}
-
-func (c *clientHandler) storeOrAppend(conn net.Conn, file FileStream) (int64, error) {
-	if c.ctxRest != 0 {
-		file.Seek(c.ctxRest, 0)
-		c.ctxRest = 0
-	}
-
-	return io.Copy(file, conn)
 }
 
 func (c *clientHandler) handleDELE() {

--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -28,7 +28,15 @@ func (c *clientHandler) handleStoreAndAppend(append bool) {
 
 	if tr, err := c.TransferOpen(); err == nil {
 		defer c.TransferClose()
-		if _, err := c.storeOrAppend(tr, file); err != nil && err != io.EOF {
+
+		_, err := c.storeOrAppend(tr, file)
+		if err != nil && err != io.EOF {
+			c.writeMessage(550, err.Error())
+			file.Close()
+			return
+		}
+
+		if err := file.Close(); err != nil {
 			c.writeMessage(550, err.Error())
 		}
 	} else {
@@ -100,7 +108,6 @@ func (c *clientHandler) storeOrAppend(conn net.Conn, file FileStream) (int64, er
 		c.ctxRest = 0
 	}
 
-	defer file.Close()
 	return io.Copy(file, conn)
 }
 

--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -38,11 +38,13 @@ type ServerDriver struct {
 	TLS   bool
 
 	Settings *server.Settings // Settings
+	server.FileStream
 }
 
 // ClientDriver defines a minimal serverftp client driver
 type ClientDriver struct {
 	baseDir string
+	server.FileStream
 }
 
 // NewClientDriver creates a client driver
@@ -62,7 +64,11 @@ func (driver *ServerDriver) WelcomeUser(cc server.ClientContext) (string, error)
 // AuthUser with authenticate users
 func (driver *ServerDriver) AuthUser(cc server.ClientContext, user, pass string) (server.ClientHandlingDriver, error) {
 	if user == "test" && pass == "test" {
-		return NewClientDriver(), nil
+		clientdriver := NewClientDriver()
+		if driver.FileStream != nil {
+			clientdriver.FileStream = driver.FileStream
+		}
+		return clientdriver, nil
 	}
 	return nil, errors.New("bad username or password")
 }
@@ -117,6 +123,10 @@ func (driver *ClientDriver) OpenFile(cc server.ClientContext, path string, flag 
 		if (flag & os.O_APPEND) == 0 {
 			os.Remove(path)
 		}
+	}
+
+	if driver.FileStream != nil {
+		return driver.FileStream, nil
 	}
 
 	return os.OpenFile(path, flag, 0666)


### PR DESCRIPTION
If a `FileStream` fails on `Close` (e.g. due to a failing hard drive), the error should get propagated to the client.