### PR TITLE
Restoring the debug mode in tests

### DIFF
--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/fclairamb/ftpserver/server"
+	"github.com/go-kit/kit/log"
 )
 
 // NewTestServer provides a test server with or without debugging
@@ -25,6 +26,16 @@ func NewTestServerWithDriver(driver *ServerDriver) *server.FtpServer {
 	}
 
 	s := server.NewFtpServer(driver)
+
+	// If we are in debug mode, we should log things
+	if driver.Debug {
+		s.Logger = log.With(
+			log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+			"ts", log.DefaultTimestampUTC,
+			"caller", log.DefaultCaller,
+		)
+	}
+
 	if err := s.Listen(); err != nil {
 		return nil
 	}


### PR DESCRIPTION
By changing the logging logic on the server side I broke the debug mechanism used in tests.

This PR restores it.