### PR TITLE
Dealing with file access errors

### DIFF
--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -19,29 +19,39 @@ func (c *clientHandler) handleAPPE() {
 
 // Handles both the "STOR" and "APPE" commands
 func (c *clientHandler) handleStoreAndAppend(append bool) {
+	if err := c.storeOrAppend(append); err != nil {
+		c.writeMessage(550, err.Error())
+	}
+}
+
+func (c *clientHandler) storeOrAppend(append bool) (err error) {
 	file, err := c.openFile(c.absPath(c.param), append)
-
 	if err != nil {
-		c.writeMessage(550, "Could not open file: "+err.Error())
-		return
+		return fmt.Errorf("Could not open file: %s", err)
 	}
 
-	if tr, err := c.TransferOpen(); err == nil {
-		defer c.TransferClose()
-
-		_, err := c.storeOrAppend(tr, file)
-		if err != nil && err != io.EOF {
-			c.writeMessage(550, err.Error())
-			file.Close()
-			return
+	defer func() {
+		if errClose := file.Close(); errClose != nil && err == nil {
+			err = errClose
 		}
+	}()
 
-		if err := file.Close(); err != nil {
-			c.writeMessage(550, err.Error())
-		}
-	} else {
-		c.writeMessage(550, "Could not open transfer: "+err.Error())
+	tr, err := c.TransferOpen()
+	if err != nil {
+		return fmt.Errorf("Could not open transfer: %s", err)
 	}
+	defer c.TransferClose()
+
+	if c.ctxRest != 0 {
+		file.Seek(c.ctxRest, 0)
+		c.ctxRest = 0
+	}
+
+	if _, err := io.Copy(file, tr); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
 }
 
 func (c *clientHandler) openFile(path string, append bool) (FileStream, error) {
@@ -100,15 +110,6 @@ func (c *clientHandler) handleCHMOD(params string) {
 	}
 
 	c.writeMessage(200, "SITE CHMOD command successful")
-}
-
-func (c *clientHandler) storeOrAppend(conn net.Conn, file FileStream) (int64, error) {
-	if c.ctxRest != 0 {
-		file.Seek(c.ctxRest, 0)
-		c.ctxRest = 0
-	}
-
-	return io.Copy(file, conn)
 }
 
 func (c *clientHandler) handleDELE() {

--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -10,87 +10,89 @@ import (
 )
 
 func (c *clientHandler) handleSTOR() {
-	c.handleStoreAndAppend(false)
+	c.transferFile(true, false)
 }
 
 func (c *clientHandler) handleAPPE() {
-	c.handleStoreAndAppend(true)
-}
-
-// Handles both the "STOR" and "APPE" commands
-func (c *clientHandler) handleStoreAndAppend(append bool) {
-	if err := c.storeOrAppend(append); err != nil {
-		c.writeMessage(550, err.Error())
-	}
-}
-
-func (c *clientHandler) storeOrAppend(append bool) (err error) {
-	file, err := c.openFile(c.absPath(c.param), append)
-	if err != nil {
-		return fmt.Errorf("Could not open file: %s", err)
-	}
-
-	defer func() {
-		if errClose := file.Close(); errClose != nil && err == nil {
-			err = errClose
-		}
-	}()
-
-	tr, err := c.TransferOpen()
-	if err != nil {
-		return fmt.Errorf("Could not open transfer: %s", err)
-	}
-	defer c.TransferClose()
-
-	if c.ctxRest != 0 {
-		file.Seek(c.ctxRest, 0)
-		c.ctxRest = 0
-	}
-
-	if _, err := io.Copy(file, tr); err != nil && err != io.EOF {
-		return err
-	}
-
-	return nil
-}
-
-func (c *clientHandler) openFile(path string, append bool) (FileStream, error) {
-	flag := os.O_WRONLY
-	if append {
-		flag |= os.O_APPEND
-	}
-
-	return c.driver.OpenFile(c, path, flag)
+	c.transferFile(true, true)
 }
 
 func (c *clientHandler) handleRETR() {
-
-	path := c.absPath(c.param)
-
-	if tr, err := c.TransferOpen(); err == nil {
-		defer c.TransferClose()
-		if _, err := c.download(tr, path); err != nil && err != io.EOF {
-			c.writeMessage(550, err.Error())
-		}
-	} else {
-		c.writeMessage(550, err.Error())
-	}
+	c.transferFile(false, false)
 }
 
-func (c *clientHandler) download(conn net.Conn, name string) (int64, error) {
-	file, err := c.driver.OpenFile(c, name, os.O_RDONLY)
+// File transfer, read or write, seek or not, is basically the same.
+// To make sure we don't miss any step, we execute everything in order
+func (c *clientHandler) transferFile(write bool, append bool) {
 
-	if err != nil {
-		return 0, err
+	var file FileStream
+	var err error
+
+	// We try to open the file
+	{
+		var fileFlag int
+		if write {
+			fileFlag = os.O_WRONLY
+			if append {
+				fileFlag |= os.O_APPEND
+			}
+		} else {
+			fileFlag = os.O_RDONLY
+		}
+
+		// If this fail, can stop right here
+		if file, err = c.driver.OpenFile(c, c.absPath(c.param), fileFlag); err != nil {
+			c.writeMessage(550, "Could not access file: "+err.Error())
+			return
+		}
 	}
 
+	// Try to seek on it
 	if c.ctxRest != 0 {
-		file.Seek(c.ctxRest, 0)
+		if err == nil {
+			if _, errSeek := file.Seek(c.ctxRest, 0); errSeek != nil {
+				err = errSeek
+			}
+		}
+
+		// Whatever happens we should reset the seek position
 		c.ctxRest = 0
 	}
 
-	defer file.Close()
-	return io.Copy(conn, file)
+	// Start the transfer
+	if err == nil {
+		var tr net.Conn
+		if tr, err = c.TransferOpen(); err == nil {
+			defer c.TransferClose()
+
+			// Copy the data
+			var in io.Reader
+			var out io.Writer
+
+			if write { // ... from the connection to the file
+				in = tr
+				out = file
+			} else { // ... from the file to the connection
+				in = file
+				out = tr
+			}
+
+			if _, errCopy := io.Copy(out, in); errCopy != nil && errCopy != io.EOF {
+				err = errCopy
+			}
+		}
+	}
+
+	// *ALWAYS* close the file but only save the error if there wasn't one before
+	// Note: We could discard the error in read mode
+	if errClose := file.Close(); errClose != nil && err == nil {
+		err = errClose
+	}
+
+	if err != nil {
+		c.writeMessage(550, "Could not transfer file: "+err.Error())
+		return
+	}
 }
 
 func (c *clientHandler) handleCHMOD(params string) {

--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -28,7 +28,15 @@ func (c *clientHandler) handleStoreAndAppend(append bool) {
 
 	if tr, err := c.TransferOpen(); err == nil {
 		defer c.TransferClose()
-		if _, err := c.storeOrAppend(tr, file); err != nil && err != io.EOF {
+
+		_, err := c.storeOrAppend(tr, file)
+		if err != nil && err != io.EOF {
+			c.writeMessage(550, err.Error())
+			file.Close()
+			return
+		}
+
+		if err := file.Close(); err != nil {
 			c.writeMessage(550, err.Error())
 		}
 	} else {
@@ -100,7 +108,6 @@ func (c *clientHandler) storeOrAppend(conn net.Conn, file FileStream) (int64, er
 		c.ctxRest = 0
 	}
 
-	defer file.Close()
 	return io.Copy(file, conn)
 }
 

--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -38,11 +38,13 @@ type ServerDriver struct {
 	TLS   bool
 
 	Settings *server.Settings // Settings
+	server.FileStream
 }
 
 // ClientDriver defines a minimal serverftp client driver
 type ClientDriver struct {
 	baseDir string
+	server.FileStream
 }
 
 // NewClientDriver creates a client driver
@@ -62,7 +64,11 @@ func (driver *ServerDriver) WelcomeUser(cc server.ClientContext) (string, error)
 // AuthUser with authenticate users
 func (driver *ServerDriver) AuthUser(cc server.ClientContext, user, pass string) (server.ClientHandlingDriver, error) {
 	if user == "test" && pass == "test" {
-		return NewClientDriver(), nil
+		clientdriver := NewClientDriver()
+		if driver.FileStream != nil {
+			clientdriver.FileStream = driver.FileStream
+		}
+		return clientdriver, nil
 	}
 	return nil, errors.New("bad username or password")
 }
@@ -117,6 +123,10 @@ func (driver *ClientDriver) OpenFile(cc server.ClientContext, path string, flag 
 		if (flag & os.O_APPEND) == 0 {
 			os.Remove(path)
 		}
+	}
+
+	if driver.FileStream != nil {
+		return driver.FileStream, nil
 	}
 
 	return os.OpenFile(path, flag, 0666)


### PR DESCRIPTION
This PR addresses #66, #69, #70:
- Always close an opened file
- Check the file closure
- Check the file seek (not reported but we might as well do it)
- Share the code between download and upload

Note: If the file closure fails during reading, it's reported as an error. I'm not sure it's something that we actually want. If someone is against it, he can complain.

Before this fix:
- Failure to close (and flush) a file would not be visible from a client side. Which might give the (very wrong) idea that the file was correctly written.
- Failure to create a transfer connection creates a file descriptor leak
- Failure to seek on a file is ignored (unlikely but definitely bad)