### PR TITLE
Send absolute path parameter to ClientDriver.ListFiles

### DIFF
--- a/sample/sample_driver.go
+++ b/sample/sample_driver.go
@@ -222,9 +222,9 @@ func (driver *ClientDriver) MakeDirectory(cc server.ClientContext, directory str
 }
 
 // ListFiles lists the files of a directory
-func (driver *ClientDriver) ListFiles(cc server.ClientContext) ([]os.FileInfo, error) {
+func (driver *ClientDriver) ListFiles(cc server.ClientContext, directory string) ([]os.FileInfo, error) {
 
-	if cc.Path() == "/virtual" {
+	if directory == "/virtual" {
 		files := make([]os.FileInfo, 0)
 		files = append(files,
 			virtualFileInfo{
@@ -239,16 +239,14 @@ func (driver *ClientDriver) ListFiles(cc server.ClientContext) ([]os.FileInfo, e
 			},
 		)
 		return files, nil
-	} else if cc.Path() == "/debug" {
+	} else if directory == "/debug" {
 		return make([]os.FileInfo, 0), nil
 	}
 
-	path := driver.BaseDir + cc.Path()
-
-	files, err := ioutil.ReadDir(path)
+	files, err := ioutil.ReadDir(directory)
 
 	// We add a virtual dir
-	if cc.Path() == "/" && err == nil {
+	if directory == "/" && err == nil {
 		files = append(files, virtualFileInfo{
 			name: "virtual",
 			mode: os.FileMode(0666) | os.ModeDir,

--- a/server/driver.go
+++ b/server/driver.go
@@ -37,7 +37,7 @@ type ClientHandlingDriver interface {
 	MakeDirectory(cc ClientContext, directory string) error
 
 	// ListFiles lists the files of a directory
-	ListFiles(cc ClientContext) ([]os.FileInfo, error)
+	ListFiles(cc ClientContext, directory string) ([]os.FileInfo, error)
 
 	// OpenFile opens a file in 3 possible modes: read, write, appending write (use appropriate flags)
 	OpenFile(cc ClientContext, path string, flag int) (FileStream, error)

--- a/server/handle_dirs.go
+++ b/server/handle_dirs.go
@@ -84,7 +84,7 @@ func (c *clientHandler) handlePWD() {
 }
 
 func (c *clientHandler) handleLIST() {
-	if files, err := c.driver.ListFiles(c); err == nil {
+	if files, err := c.driver.ListFiles(c, c.absPath(c.param)); err == nil {
 		if tr, err := c.TransferOpen(); err == nil {
 			defer c.TransferClose()
 			c.dirTransferLIST(tr, files)
@@ -99,7 +99,7 @@ func (c *clientHandler) handleMLSD() {
 		c.writeMessage(500, "MLSD has been disabled")
 		return
 	}
-	if files, err := c.driver.ListFiles(c); err == nil {
+	if files, err := c.driver.ListFiles(c, c.absPath(c.param)); err == nil {
 		if tr, err := c.TransferOpen(); err == nil {
 			defer c.TransferClose()
 			c.dirTransferMLSD(tr, files)

--- a/server/handle_files.go
+++ b/server/handle_files.go
@@ -160,7 +160,7 @@ func (c *clientHandler) handleSTATFile() {
 	if info, err := c.driver.GetFileInfo(c, path); err == nil {
 		c.writeLine("211-Status follows:")
 		if info.IsDir() {
-			if files, err := c.driver.ListFiles(c); err == nil {
+			if files, err := c.driver.ListFiles(c, c.absPath(c.param)); err == nil {
 				for _, f := range files {
 					c.writeLine(fmt.Sprintf(" %s", c.fileStat(f)))
 				}

--- a/tests/handle_dirs_test.go
+++ b/tests/handle_dirs_test.go
@@ -51,6 +51,48 @@ func TestDirListing(t *testing.T) {
 			t.Fatal("Couldn't find the dir")
 		}
 	}
+
+	if err := ftp.Mkd("/known/1"); err != nil {
+		t.Fatal("Couldn't create dir:", err)
+	}
+
+	if lines, err := ftp.List("known"); err != nil {
+		t.Fatal("Couldn't list files:", err)
+	} else {
+		found := false
+		for _, line := range lines {
+			line = line[0 : len(line)-2]
+			if len(line) < 47 {
+				break
+			}
+			fileName := line[47:]
+			if fileName == "1" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("Couldn't find the dir")
+		}
+	}
+
+	if lines, err := ftp.List(""); err != nil {
+		t.Fatal("Couldn't list files:", err)
+	} else {
+		found := false
+		for _, line := range lines {
+			line = line[0 : len(line)-2]
+			if len(line) < 47 {
+				break
+			}
+			fileName := line[47:]
+			if fileName == "known" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("Couldn't find the dir")
+		}
+	}
 }
 
 // TestDirAccess relies on LIST of files listing

--- a/tests/test_driver.go
+++ b/tests/test_driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/fclairamb/ftpserver/server"
 	"github.com/go-kit/kit/log"
@@ -118,9 +119,12 @@ func (driver *ClientDriver) MakeDirectory(cc server.ClientContext, directory str
 }
 
 // ListFiles lists the files of a directory
-func (driver *ClientDriver) ListFiles(cc server.ClientContext) ([]os.FileInfo, error) {
-	path := driver.baseDir + cc.Path()
-	files, err := ioutil.ReadDir(path)
+func (driver *ClientDriver) ListFiles(cc server.ClientContext, directory string) ([]os.FileInfo, error) {
+	p := path.Join(driver.baseDir, directory)
+	if directory == "" {
+		p = driver.baseDir + cc.Path()
+	}
+	files, err := ioutil.ReadDir(p)
 	return files, err
 }
 


### PR DESCRIPTION
Fixes #93 -- Its a breaking API change, but it does empower client implementations to be much more flexible. Allows FTP client to send a path parameter for `LIST` or `MLSD` and avoid using `ClientContext.Path()` to determine the intended directory to list (which is not what it should be used for as it represents FTP clients current working directory).

Path parameter can be absolute or relative. `LIST some/subfolder` or `LIST /root/some/subfolder`. The parameter sent to `ClientHandlingDriver.ListFiles` is always an absolute path, client can strip the `ClientContext.Path()` prefix from it if they want to make it relative.

Tested and working.