### PR TITLE
fix tcpListener nil pointer dereference

### DIFF
--- a/server/transfer_pasv.go
+++ b/server/transfer_pasv.go
@@ -71,8 +71,8 @@ func (c *clientHandler) handlePASV() error {
 				continue
 			}
 
-			tcpListener, err2 = net.ListenTCP("tcp", laddr)
-			if err2 == nil {
+			tcpListener, err = net.ListenTCP("tcp", laddr)
+			if err == nil {
 				break
 			}
 		}


### PR DESCRIPTION
it happens in case of exhaustion of passive ports