### PR TITLE
use path.Clean() instead of our own absPath()

### DIFF
--- a/server/handle_dirs.go
+++ b/server/handle_dirs.go
@@ -13,9 +13,8 @@ import (
 func (c *clientHandler) absPath(p string) string {
 	if strings.HasPrefix(p, "/") {
 		return path.Clean(p)
-	} else {
-		return path.Clean(c.Path() + "/" + p)
 	}
+	return path.Clean(c.Path() + "/" + p)
 }
 
 func (c *clientHandler) handleCWD() error {

--- a/server/handle_dirs.go
+++ b/server/handle_dirs.go
@@ -11,33 +11,14 @@ import (
 )
 
 func (c *clientHandler) absPath(p string) string {
-	p2 := c.Path()
-
-	if p == "." {
-		return p2
-	}
-
 	if strings.HasPrefix(p, "/") {
-		p2 = p
+		return path.Clean(p)
 	} else {
-		if p2 != "/" {
-			p2 += "/"
-		}
-		p2 += p
+		return path.Clean(c.Path() + "/" + p)
 	}
-
-	if p2 != "/" && strings.HasSuffix(p2, "/") {
-		p2 = p2[0 : len(p2)-1]
-	}
-
-	return p2
 }
 
 func (c *clientHandler) handleCWD() error {
-	if c.param == ".." {
-		return c.handleCDUP()
-	}
-
 	p := c.absPath(c.param)
 
 	if err := c.driver.ChangeDirectory(c, p); err == nil {

--- a/server/handle_dirs.go
+++ b/server/handle_dirs.go
@@ -14,6 +14,7 @@ func (c *clientHandler) absPath(p string) string {
 	if strings.HasPrefix(p, "/") {
 		return path.Clean(p)
 	}
+
 	return path.Clean(c.Path() + "/" + p)
 }
 

--- a/tests/handle_dirs_test.go
+++ b/tests/handle_dirs_test.go
@@ -264,6 +264,7 @@ func TestCleanPath(t *testing.T) {
 		if err := ftp.Cwd(dir); err != nil {
 			t.Fatal("Couldn't Cwd to a valid path:", err)
 		}
+
 		if path, err := ftp.Pwd(); err != nil {
 			t.Fatal("PWD failed:", err)
 		} else if path != "/" {

--- a/tests/handle_dirs_test.go
+++ b/tests/handle_dirs_test.go
@@ -232,3 +232,42 @@ func TestDirListingWithSpace(t *testing.T) {
 		t.Fatal("Couldn't access the known dir:", err)
 	}
 }
+
+func TestCleanPath(t *testing.T) {
+	s := NewTestServer(true)
+	defer s.Stop()
+
+	var connErr error
+
+	var ftp *goftp.FTP
+
+	if ftp, connErr = goftp.Connect(s.Addr()); connErr != nil {
+		t.Fatal("Couldn't connect", connErr)
+	}
+
+	defer func() { panicOnError(ftp.Quit()) }()
+
+	if err := ftp.Login("test", "test"); err != nil {
+		t.Fatal("Failed to login:", err)
+	}
+
+	// various path purity tests
+
+	for _, dir := range []string{
+		"..",
+		"../..",
+		"/../..",
+		"////",
+		"/./",
+		"/././.",
+	} {
+		if err := ftp.Cwd(dir); err != nil {
+			t.Fatal("Couldn't Cwd to a valid path:", err)
+		}
+		if path, err := ftp.Pwd(); err != nil {
+			t.Fatal("PWD failed:", err)
+		} else if path != "/" {
+			t.Fatal("Faulty path:", path)
+		}
+	}
+}


### PR DESCRIPTION
Hello!

During your library exploitation I've discovered several cases when the path isn't properly handled. You can see some of them in the test I wrote. So I suggest to use standard path.Clean() here.

This will not work for an operating systems where os.Separator is not "/" (i.e. Windows). But as far as I can see path.Split() (that relies on os.Separator too) is already used in handleCDUP so I concluded that nobody really cares.

Thx in advance!