### PR TITLE
transfer open: add error checking

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -258,8 +258,17 @@ func (c *clientHandler) TransferOpen() (net.Conn, error) {
 		return nil, errors.New("no passive connection declared")
 	}
 
-	c.writeMessage(StatusFileStatusOK, "Using transfer connection")
 	conn, err := c.transfer.Open()
+	if err != nil {
+		c.logger.Warn(
+			"Unable to open transfer",
+			"error", err)
+		c.writeMessage(StatusCannotOpenDataConnection, fmt.Sprintf("Unable to open transfer: %v", err))
+
+		return conn, err
+	}
+
+	c.writeMessage(StatusFileStatusOK, "Using transfer connection")
 
 	if err == nil && c.debug {
 		c.logger.Debug(

--- a/consts.go
+++ b/consts.go
@@ -38,8 +38,9 @@ const (
 
 	// 400 Series - The command was not accepted and the requested action did not take place,
 	// but the error condition is temporary and the action may be requested again.
-	StatusServiceNotAvailable = 421 // RFC 959, 4.2.1
-	StatusFileActionNotTaken  = 450 // RFC 959, 4.2.1
+	StatusServiceNotAvailable      = 421 // RFC 959, 4.2.1
+	StatusCannotOpenDataConnection = 425 // RFC 959, 4.2.1
+	StatusFileActionNotTaken       = 450 // RFC 959, 4.2.1
 
 	// 500 Series - Syntax error, command unrecognized and the requested action did not take
 	// place. This may include errors such as command line too long.

--- a/handle_files.go
+++ b/handle_files.go
@@ -32,7 +32,6 @@ func (c *clientHandler) handleRETR() error {
 // To make sure we don't miss any step, we execute everything in order
 func (c *clientHandler) transferFile(write bool, append bool) {
 	var file afero.File
-
 	var err error
 
 	path := c.absPath(c.param)
@@ -77,9 +76,7 @@ func (c *clientHandler) transferFile(write bool, append bool) {
 			defer c.TransferClose()
 
 			// Copy the data
-
 			var in io.Reader
-
 			var out io.Writer
 
 			if write { // ... from the connection to the file
@@ -107,8 +104,11 @@ func (c *clientHandler) transferFile(write bool, append bool) {
 	}
 
 	if err != nil {
-		c.writeMessage(StatusActionNotTaken, "Could not transfer file: "+err.Error())
-		return
+		// if the transfer could not be open we already sent an error
+		if _, isOpenTransferErr := err.(*openTransferError); !isOpenTransferErr {
+			c.writeMessage(StatusActionNotTaken, "Could not transfer file: "+err.Error())
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
send `StatusFileStatusOK` only if `transfer.Open()` returns no error.
If an error happen send a 425 error code.

This patch fixes the following use case:

1) start the ftpserver as non root user
2) start an active connection
3) request file list

if the server is not started as root and `ActiveTransferPortNon20` is not set then the server cannot bind to port 20.

Before the patch this response is sent [anyway](https://github.com/fclairamb/ftpserverlib/blob/master/client_handler.go#L261):

```
c.writeMessage(StatusFileStatusOK, "Using transfer connection")
```

and the client hangs forever.

After this patch the ftp client receive this error:

```
ftp> ls
200 PORT command successful
425 Unable to open transfer: could not establish active connection due: dial tcp :20->127.0.0.1:37811: bind: permission denied
```

tested using ftp CLI on Linux