### PR TITLE
add support for multi-line replies

### DIFF
--- a/client_handler_test.go
+++ b/client_handler_test.go
@@ -37,3 +37,64 @@ func TestConcurrency(t *testing.T) {
 
 	waitGroup.Wait()
 }
+
+type multilineMessage struct {
+	message       string
+	expectedLines []string
+}
+
+func TestMultiLineMessages(t *testing.T) {
+	testMultilines := []multilineMessage{
+		{
+			message:       "single line",
+			expectedLines: []string{"single line"},
+		},
+		{
+			message:       "",
+			expectedLines: []string{""},
+		},
+		{
+			message:       "first line\r\nsecond line\r\n",
+			expectedLines: []string{"first line", "second line"},
+		},
+		{
+			message:       "first line\nsecond line\n",
+			expectedLines: []string{"first line", "second line"},
+		},
+		{
+			message:       "first line\rsecond line",
+			expectedLines: []string{"first line\rsecond line"},
+		},
+		{
+			message: `first line
+
+second line
+
+`,
+			expectedLines: []string{"first line", "", "second line", ""},
+		},
+	}
+
+	for _, msg := range testMultilines {
+		lines := getMessageLines(msg.message)
+		if len(lines) != len(msg.expectedLines) {
+			t.Errorf("unexpected number of lines got: %v want: %v", len(lines), len(msg.expectedLines))
+		}
+
+		for _, line := range lines {
+			if !isStringInSlice(line, msg.expectedLines) {
+				t.Errorf("unexpected line %#v", line)
+			}
+		}
+	}
+}
+
+func isStringInSlice(s string, list []string) bool {
+	for _, c := range list {
+		if s == c {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This allows, for example, to send an initial multi-line banner