### PR TITLE
add a setting to require TLS

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -304,7 +304,7 @@ func (c *clientHandler) TransferOpen() (net.Conn, error) {
 		return nil, err
 	}
 
-	if c.server.settings.TSLMode == 1 && !c.transferTLS {
+	if c.server.settings.TLSRequired == 1 && !c.transferTLS {
 		err := &openTransferError{err: "TLS is required"}
 		c.writeMessage(StatusServiceNotAvailable, err.Error())
 

--- a/client_handler.go
+++ b/client_handler.go
@@ -39,6 +39,7 @@ type clientHandler struct {
 	debug       bool            // Show debugging info on the server side
 	transfer    transferHandler // Transfer connection (only passive is implemented at this stage)
 	transferTLS bool            // Use TLS for transfer connection
+	controlTLS  bool            // Use TLS for control connection
 	logger      log.Logger      // Client handler logging
 }
 
@@ -299,6 +300,13 @@ func (c *clientHandler) TransferOpen() (net.Conn, error) {
 	if c.transfer == nil {
 		err := &openTransferError{err: "No passive connection declared"}
 		c.writeMessage(StatusActionNotTaken, err.Error())
+
+		return nil, err
+	}
+
+	if c.server.settings.TSLMode == 1 && !c.transferTLS {
+		err := &openTransferError{err: "TLS is required"}
+		c.writeMessage(StatusServiceNotAvailable, err.Error())
 
 		return nil, err
 	}

--- a/driver.go
+++ b/driver.go
@@ -161,5 +161,5 @@ type Settings struct {
 	// 1 means TLS in required for both control and data connection
 	// Do not enable this blindly, please check that a proper TLS config
 	// is in place or no login will be allowed
-	TSLMode int
+	TLSRequired int
 }

--- a/driver.go
+++ b/driver.go
@@ -157,4 +157,9 @@ type Settings struct {
 	DisableMLST              bool             // Disable MLST support
 	DisableMFMT              bool             // Disable MFMT support (modify file mtime)
 	Banner                   string           // Banner to use in server status response
+	// 0 means accept both cleartext and encrypted sessions
+	// 1 means TLS in required for both control and data connection
+	// Do not enable this blindly, please check that a proper TLS config
+	// is in place or no login will be allowed
+	TSLMode int
 }

--- a/handle_auth.go
+++ b/handle_auth.go
@@ -5,6 +5,11 @@ import "fmt"
 
 // Handle the "USER" command
 func (c *clientHandler) handleUSER() error {
+	if c.server.settings.TSLMode == 1 && !c.controlTLS {
+		c.writeMessage(StatusServiceNotAvailable, "TLS is required")
+		return nil
+	}
+
 	c.user = c.param
 	c.writeMessage(StatusUserOK, "OK")
 

--- a/handle_auth.go
+++ b/handle_auth.go
@@ -5,7 +5,7 @@ import "fmt"
 
 // Handle the "USER" command
 func (c *clientHandler) handleUSER() error {
-	if c.server.settings.TSLMode == 1 && !c.controlTLS {
+	if c.server.settings.TLSRequired == 1 && !c.controlTLS {
 		c.writeMessage(StatusServiceNotAvailable, "TLS is required")
 		return nil
 	}

--- a/handle_auth_test.go
+++ b/handle_auth_test.go
@@ -98,7 +98,7 @@ func TestAuthTLSRequired(t *testing.T) {
 		Debug: true,
 		TLS:   true,
 	})
-	s.settings.TSLMode = 1
+	s.settings.TLSRequired = 1
 
 	ftp, err := goftp.Connect(s.Addr())
 	if err != nil {

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -1,6 +1,7 @@
 package ftpserver
 
 import (
+	"crypto/tls"
 	"runtime"
 	"strings"
 	"testing"
@@ -267,5 +268,47 @@ func TestCleanPath(t *testing.T) {
 		} else if path != "/" {
 			t.Fatal("Faulty path:", path)
 		}
+	}
+}
+
+func TestTLSTransfer(t *testing.T) {
+	s := NewTestServerWithDriver(t, &TestServerDriver{
+		Debug: true,
+		TLS:   true,
+	})
+	s.settings.TSLMode = 1
+
+	ftp, err := goftp.Connect(s.Addr())
+	if err != nil {
+		t.Fatal("Couldn't connect:", err)
+	}
+
+	defer func() { reportError(ftp.Quit()) }()
+
+	config := &tls.Config{
+		// nolint:gosec
+		InsecureSkipVerify: true,
+	}
+	if err = ftp.AuthTLS(config); err != nil {
+		t.Fatal("Couldn't upgrade connection to TLS:", err)
+	}
+
+	if err = ftp.Login("test", "test"); err != nil {
+		t.Fatal("Failed to login:", err)
+	}
+
+	if _, err := ftp.List("/"); err != nil {
+		t.Fatal("Couldn't list files")
+	}
+
+	code, _ := ftp.RawCmd("PROT C")
+	if code != StatusOK {
+		t.Fatal("unable to send PROT C")
+	}
+
+	if _, err := ftp.List("/"); err == nil {
+		t.Fatal("List files should fail, TLS is required")
+	} else if !strings.Contains(err.Error(), "TLS is required") {
+		t.Fatal("unexpected error:", err)
 	}
 }

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -276,7 +276,7 @@ func TestTLSTransfer(t *testing.T) {
 		Debug: true,
 		TLS:   true,
 	})
-	s.settings.TSLMode = 1
+	s.settings.TLSRequired = 1
 
 	ftp, err := goftp.Connect(s.Addr())
 	if err != nil {

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -15,6 +15,7 @@ func (c *clientHandler) handleAUTH() error {
 		c.conn = tls.Server(c.conn, tlsConfig)
 		c.reader = bufio.NewReader(c.conn)
 		c.writer = bufio.NewWriter(c.conn)
+		c.controlTLS = true
 	} else {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Cannot get a TLS config: %v", err))
 	}


### PR DESCRIPTION
TLSMode is an int since in future we could add other options, for
example require TLS for control connection but not for data connection.

@fclairamb thank you for giving me push permissions! I prefer a review anyway instead of pushing directly my changes 