### PR TITLE
Add support for EPRT (Extended Port) according to RFC 2428. This was missing for full IPv6 support (Active Mode).

### DIFF
--- a/server.go
+++ b/server.go
@@ -71,6 +71,7 @@ var commandsMap = map[string]*CommandDescription{
 	"PASV": {Fn: (*clientHandler).handlePASV},
 	"EPSV": {Fn: (*clientHandler).handlePASV},
 	"PORT": {Fn: (*clientHandler).handlePORT},
+	"EPRT": {Fn: (*clientHandler).handlePORT},
 }
 
 // FtpServer is where everything is stored


### PR DESCRIPTION
Support for EPRT #187 according to RFC 2428. This was missing for full IPv6 support (Active Mode).