### PR TITLE
add support for implicit TLS

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -108,6 +108,24 @@ func (c *clientHandler) GetClientVersion() string {
 	return c.clnt
 }
 
+// HasTLSForControl returns true if the control connection is over TLS
+func (c *clientHandler) HasTLSForControl() bool {
+	if c.server.settings.TLSRequired == ImplicitEncryption {
+		return true
+	}
+
+	return c.controlTLS
+}
+
+// HasTLSForTransfers returns true if the transfer connection is over TLS
+func (c *clientHandler) HasTLSForTransfers() bool {
+	if c.server.settings.TLSRequired == ImplicitEncryption {
+		return true
+	}
+
+	return c.transferTLS
+}
+
 // Close closes the active transfer, if any, and the control connection
 func (c *clientHandler) Close(code int, message string) error {
 	if c.transfer != nil {
@@ -304,7 +322,7 @@ func (c *clientHandler) TransferOpen() (net.Conn, error) {
 		return nil, err
 	}
 
-	if c.server.settings.TLSRequired == 1 && !c.transferTLS {
+	if c.server.settings.TLSRequired == MandatoryEncryption && !c.transferTLS {
 		err := &openTransferError{err: "TLS is required"}
 		c.writeMessage(StatusServiceNotAvailable, err.Error())
 

--- a/client_handler_test.go
+++ b/client_handler_test.go
@@ -53,7 +53,7 @@ func TestTLSMethods(t *testing.T) {
 		require.False(t, cc.HasTLSForTransfers())
 	})
 
-	t.Run("wit-implicit-tls", func(t *testing.T) {
+	t.Run("with-implicit-tls", func(t *testing.T) {
 		s := NewTestServerWithDriver(t, &TestServerDriver{
 			Settings: &Settings{
 				TLSRequired: ImplicitEncryption,

--- a/client_handler_test.go
+++ b/client_handler_test.go
@@ -1,14 +1,16 @@
 package ftpserver
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
-	"gopkg.in/dutchcoders/goftp.v1"
+	"github.com/secsy/goftp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConcurrency(t *testing.T) {
-	s := NewTestServer(t, false)
+	server := NewTestServer(t, false)
 
 	nbClients := 100
 
@@ -17,24 +19,52 @@ func TestConcurrency(t *testing.T) {
 
 	for i := 0; i < nbClients; i++ {
 		go func() {
+			conf := goftp.Config{
+				User:     authUser,
+				Password: authPass,
+			}
+
 			var err error
-			var ftp *goftp.FTP
+			var c *goftp.Client
 
-			if ftp, err = goftp.Connect(s.Addr()); err != nil {
-				panic(err)
+			if c, err = goftp.DialConfig(conf, server.Addr()); err != nil {
+				panic(fmt.Sprintf("Couldn't connect: %v", err))
 			}
 
-			defer func() { panicOnError(ftp.Close()) }()
-
-			if err = ftp.Login("test", "test"); err != nil {
-				panic(err)
+			if _, err = c.ReadDir("/"); err != nil {
+				panic(fmt.Sprintf("Couldn't list dir: %v", err))
 			}
+
+			defer func() { panicOnError(c.Close()) }()
 
 			waitGroup.Done()
 		}()
 	}
 
 	waitGroup.Wait()
+}
+
+func TestTLSMethods(t *testing.T) {
+	t.Run("without-tls", func(t *testing.T) {
+		cc := clientHandler{
+			server: NewTestServer(t, true),
+		}
+		require.False(t, cc.HasTLSForControl())
+		require.False(t, cc.HasTLSForTransfers())
+	})
+
+	t.Run("wit-implicit-tls", func(t *testing.T) {
+		s := NewTestServerWithDriver(t, &TestServerDriver{
+			Settings: &Settings{
+				TLSRequired: ImplicitEncryption,
+			},
+		})
+		cc := clientHandler{
+			server: s,
+		}
+		require.True(t, cc.HasTLSForControl())
+		require.True(t, cc.HasTLSForTransfers())
+	})
 }
 
 type multilineMessage struct {

--- a/driver.go
+++ b/driver.go
@@ -144,6 +144,16 @@ type PortRange struct {
 // to use in the response to the PASV command, or an error if a public IP cannot be determined.
 type PublicIPResolver func(ClientContext) (string, error)
 
+// TLSRequirement is the enumerable that represents the supported TLS mode
+type TLSRequirement int
+
+// TLS modes
+const (
+	ClearOrEncrypted TLSRequirement = iota
+	MandatoryEncryption
+	ImplicitEncryption
+)
+
 // Settings defines all the server settings
 // nolint: maligned
 type Settings struct {
@@ -159,12 +169,8 @@ type Settings struct {
 	DisableMLST              bool             // Disable MLST support
 	DisableMFMT              bool             // Disable MFMT support (modify file mtime)
 	Banner                   string           // Banner to use in server status response
-	// 0 means accept both cleartext and encrypted sessions
-	// 1 means TLS in required for both control and data connection
-	// Do not enable this blindly, please check that a proper TLS config
-	// is in place or no login will be allowed
-	TLSRequired       int
-	DisableLISTArgs   bool // Disable ls like options (-a,-la etc.) for directory listing
-	DisableSite       bool // Disable SITE command
-	DisableActiveMode bool // Disable Active FTP
+	TLSRequired              TLSRequirement   // defines the TLS mode
+	DisableLISTArgs          bool             // Disable ls like options (-a,-la etc.) for directory listing
+	DisableSite              bool             // Disable SITE command
+	DisableActiveMode        bool             // Disable Active FTP
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4
 	github.com/spf13/afero v1.5.1
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/text v0.3.4 // indirect
 	gopkg.in/dutchcoders/goftp.v1 v1.0.0-20170301105846-ed59a591ce14
 )
 

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/drakkan/goftp v0.0.0-20200916091733-843d4cca4bb2 h1:aQCoXDfkaeU2/KqIvTZAcVnVmaiGdfrGF9PUnjNVjac=
@@ -184,6 +185,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -216,10 +218,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
-github.com/spf13/afero v1.4.0 h1:jsLTaI1zwYO3vjrzHalkVcIHXTNmdQFepW4OI8H3+x8=
-github.com/spf13/afero v1.4.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
-github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
-github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.5.1 h1:VHu76Lk0LSP1x254maIu2bplkWpfBWI+B+6fdoZprcg=
 github.com/spf13/afero v1.5.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -232,6 +230,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -306,6 +306,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -356,6 +358,8 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/handle_auth.go
+++ b/handle_auth.go
@@ -5,7 +5,7 @@ import "fmt"
 
 // Handle the "USER" command
 func (c *clientHandler) handleUSER() error {
-	if c.server.settings.TLSRequired == 1 && !c.controlTLS {
+	if c.server.settings.TLSRequired == MandatoryEncryption && !c.controlTLS {
 		c.writeMessage(StatusServiceNotAvailable, "TLS is required")
 		return nil
 	}

--- a/handle_auth_test.go
+++ b/handle_auth_test.go
@@ -98,7 +98,7 @@ func TestAuthTLSRequired(t *testing.T) {
 		Debug: true,
 		TLS:   true,
 	})
-	s.settings.TLSRequired = 1
+	s.settings.TLSRequired = MandatoryEncryption
 
 	ftp, err := goftp.Connect(s.Addr())
 	if err != nil {

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -277,7 +277,7 @@ func TestTLSTransfer(t *testing.T) {
 		Debug: true,
 		TLS:   true,
 	})
-	s.settings.TLSRequired = 1
+	s.settings.TLSRequired = MandatoryEncryption
 
 	ftp, err := goftp.Connect(s.Addr())
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@
 package ftpserver
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -135,6 +136,17 @@ func (server *FtpServer) Listen() error {
 		if err != nil {
 			server.Logger.Error("Cannot listen", "err", err)
 			return err
+		}
+		if server.settings.TLSRequired == ImplicitEncryption {
+			// implicit TLS
+			var tlsConfig *tls.Config
+
+			tlsConfig, err = server.driver.GetTLSConfig()
+			if err != nil {
+				server.Logger.Error("Cannot get tls config", "err", err)
+				return err
+			}
+			server.listener = tls.NewListener(server.listener, tlsConfig)
 		}
 	}
 

--- a/transfer_active.go
+++ b/transfer_active.go
@@ -26,7 +26,7 @@ func (c *clientHandler) handlePORT() error {
 
 	var tlsConfig *tls.Config
 
-	if c.transferTLS {
+	if c.transferTLS || c.server.settings.TLSRequired == ImplicitEncryption {
 		tlsConfig, err = c.server.driver.GetTLSConfig()
 		if err != nil {
 			c.writeMessage(StatusServiceNotAvailable, fmt.Sprintf("Cannot get a TLS config for active connection: %v", err))

--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -116,7 +116,7 @@ func (c *clientHandler) handlePASV() error {
 	// The listener will either be plain TCP or TLS
 	var listener net.Listener
 
-	if c.transferTLS {
+	if c.transferTLS || c.server.settings.TLSRequired == ImplicitEncryption {
 		if tlsConfig, err := c.server.driver.GetTLSConfig(); err == nil {
 			listener = tls.NewListener(tcpListener, tlsConfig)
 		} else {


### PR DESCRIPTION
This is not a standard and should not be used anymore but there are still clients requiring it.

I reused the `TLSRequired` setting, if you prefer I can add a different setting for this mode, thank you