### PR TITLE
Fixing MFMT implementation

### DIFF
--- a/handle_files.go
+++ b/handle_files.go
@@ -372,12 +372,14 @@ func (c *clientHandler) handleMFMT() error {
 	if len(params) != 2 {
 		c.writeMessage(StatusSyntaxErrorNotRecognised, fmt.Sprintf(
 			"Couldn't set mtime, not enough params, given: %s", c.param))
+		return nil
 	}
 
 	mtime, err := time.Parse("20060102150405", params[0])
 	if err != nil {
 		c.writeMessage(StatusSyntaxErrorParameters, fmt.Sprintf(
 			"Couldn't parse mtime, given: %s, err: %v", params[0], err))
+		return nil
 	}
 
 	path := c.absPath(params[1])
@@ -385,6 +387,7 @@ func (c *clientHandler) handleMFMT() error {
 	if err := c.driver.Chtimes(path, mtime, mtime); err != nil {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf(
 			"Couldn't set mtime %q for %q, err: %v", mtime.Format(time.RFC3339), path, err))
+		return nil
 	}
 
 	c.writeMessage(StatusFileStatus, fmt.Sprintf("Modify=%s; %s", params[0], params[1]))

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -200,7 +200,7 @@ func TestMFMT(t *testing.T) {
 	}
 
 	// 1 param instead of 2
-	if rc, _, err := raw.SendCommand("MFMT 202012092110"); err != nil || rc != 500 {
+	if rc, _, err := raw.SendCommand("MFMT 202012092110 file"); err != nil || rc != 500 {
 		t.Fatal("Should have failed:", err, rc)
 	}
 

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -204,7 +204,7 @@ func TestMFMT(t *testing.T) {
 		t.Fatal("Should have failed:", err, rc)
 	}
 
-	// bad date format
+	// Good (to make sure we are still in sync)
 	if rc, _, err := raw.SendCommand("MFMT 20201209211059 file"); err != nil || rc != 213 {
 		t.Fatal("Should have succeeded:", err, rc)
 	}

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -200,7 +200,7 @@ func TestMFMT(t *testing.T) {
 	}
 
 	// 1 param instead of 2
-	if rc, _, err := raw.SendCommand("MFMT 202012092110 file"); err != nil || rc != 500 {
+	if rc, _, err := raw.SendCommand("MFMT 202012092110 file"); err != nil || rc != 501 {
 		t.Fatal("Should have failed:", err, rc)
 	}
 

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -162,6 +162,54 @@ func TestCHOWN(t *testing.T) {
 	}
 }
 
+func TestMFMT(t *testing.T) {
+	s := NewTestServer(t, true)
+
+	conf := goftp.Config{
+		User:     "test",
+		Password: "test",
+	}
+
+	var err error
+
+	var c *goftp.Client
+
+	if c, err = goftp.DialConfig(conf, s.Addr()); err != nil {
+		t.Fatal("Couldn't connect", err)
+	}
+
+	defer func() { panicOnError(c.Close()) }()
+
+	// Creating a tiny file
+	ftpUpload(t, c, createTemporaryFile(t, 10), "file")
+
+	var raw goftp.RawConn
+
+	if raw, err = c.OpenRawConn(); err != nil {
+		t.Fatal("Couldn't open raw connection")
+	}
+
+	// Good
+	if rc, _, err := raw.SendCommand("MFMT 20201209211059 file"); err != nil || rc != 213 {
+		t.Fatal("Should have succeeded:", err, rc)
+	}
+
+	// 3 params instead of 2
+	if rc, _, err := raw.SendCommand("MFMT 20201209211059 file somethingelse"); err != nil || rc == 213 {
+		t.Fatal("Should have failed:", err, rc)
+	}
+
+	// 1 param instead of 2
+	if rc, _, err := raw.SendCommand("MFMT 202012092110"); err != nil || rc != 500 {
+		t.Fatal("Should have failed:", err, rc)
+	}
+
+	// bad date format
+	if rc, _, err := raw.SendCommand("MFMT 20201209211059 file"); err != nil || rc != 213 {
+		t.Fatal("Should have succeeded:", err, rc)
+	}
+}
+
 func TestSYMLINK(t *testing.T) {
 	s := NewTestServer(t, true)
 


### PR DESCRIPTION
There was a bug. It could return two responses in case of an error. And that leads to a global desync.