### PR TITLE
Fixing #162

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -3,6 +3,7 @@ package ftpserver
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,6 +25,11 @@ const (
 	HASHAlgoSHA512
 )
 
+var (
+	errNoTrasferConnection = errors.New("unable to open transfer: no transfer connection")
+	errTLSRequired         = errors.New("unable to open transfer: TLS is required")
+)
+
 func getHashMapping() map[string]HASHAlgo {
 	mapping := make(map[string]HASHAlgo)
 	mapping["CRC32"] = HASHAlgoCRC32
@@ -33,14 +39,6 @@ func getHashMapping() map[string]HASHAlgo {
 	mapping["SHA-512"] = HASHAlgoSHA512
 
 	return mapping
-}
-
-type openTransferError struct {
-	err string
-}
-
-func (e *openTransferError) Error() string {
-	return fmt.Sprintf("Unable to open transfer: %s", e.err)
 }
 
 // nolint: maligned
@@ -341,22 +339,17 @@ func (c *clientHandler) writeMessage(code int, message string) {
 	}
 }
 
-// ErrNoPassiveConnectionDeclared is defined when a transfer is openeed without any passive connection declared
-// var ErrNoPassiveConnectionDeclared = errors.New("no passive connection declared")
-
 func (c *clientHandler) TransferOpen() (net.Conn, error) {
 	if c.transfer == nil {
-		err := &openTransferError{err: "No passive connection declared"}
-		c.writeMessage(StatusActionNotTaken, err.Error())
+		c.writeMessage(StatusActionNotTaken, errNoTrasferConnection.Error())
 
-		return nil, err
+		return nil, errNoTrasferConnection
 	}
 
 	if c.server.settings.TLSRequired == MandatoryEncryption && !c.transferTLS {
-		err := &openTransferError{err: "TLS is required"}
-		c.writeMessage(StatusServiceNotAvailable, err.Error())
+		c.writeMessage(StatusServiceNotAvailable, errTLSRequired.Error())
 
-		return nil, err
+		return nil, errTLSRequired
 	}
 
 	conn, err := c.transfer.Open()
@@ -365,10 +358,9 @@ func (c *clientHandler) TransferOpen() (net.Conn, error) {
 			"Unable to open transfer",
 			"error", err)
 
-		err = &openTransferError{err: err.Error()}
 		c.writeMessage(StatusCannotOpenDataConnection, err.Error())
 
-		return conn, err
+		return nil, err
 	}
 
 	c.writeMessage(StatusFileStatusOK, "Using transfer connection")

--- a/driver_test.go
+++ b/driver_test.go
@@ -100,6 +100,7 @@ func (f *testFile) Write(b []byte) (int, error) {
 	if strings.Contains(f.File.Name(), "fail-to-write") {
 		return 0, errFailWrite
 	}
+
 	return f.File.Write(b)
 }
 
@@ -107,6 +108,7 @@ func (f *testFile) Close() error {
 	if strings.Contains(f.File.Name(), "fail-to-close") {
 		return errFailClose
 	}
+
 	return f.File.Close()
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -96,6 +96,8 @@ var errFailClose = errors.New("couldn't close")
 
 var errFailWrite = errors.New("couldn't write")
 
+var errFailSeek = errors.New("couldn't seek")
+
 func (f *testFile) Write(b []byte) (int, error) {
 	if strings.Contains(f.File.Name(), "fail-to-write") {
 		return 0, errFailWrite
@@ -110,6 +112,14 @@ func (f *testFile) Close() error {
 	}
 
 	return f.File.Close()
+}
+
+func (f *testFile) Seek(offset int64, whence int) (int64, error) {
+	if strings.Contains(f.File.Name(), "fail-to-seek") {
+		return 0, errFailSeek
+	}
+
+	return f.File.Seek(offset, whence)
 }
 
 // NewTestClientDriver creates a client driver

--- a/driver_test.go
+++ b/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	gklog "github.com/go-kit/kit/log"
@@ -85,6 +86,28 @@ type TestServerDriver struct {
 // TestClientDriver defines a minimal serverftp client driver
 type TestClientDriver struct {
 	afero.Fs
+}
+
+type testFile struct {
+	afero.File
+}
+
+var errFailClose = errors.New("couldn't close")
+
+var errFailWrite = errors.New("couldn't write")
+
+func (f *testFile) Write(b []byte) (int, error) {
+	if strings.Contains(f.File.Name(), "fail-to-write") {
+		return 0, errFailWrite
+	}
+	return f.File.Write(b)
+}
+
+func (f *testFile) Close() error {
+	if strings.Contains(f.File.Name(), "fail-to-close") {
+		return errFailClose
+	}
+	return f.File.Close()
 }
 
 // NewTestClientDriver creates a client driver

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	golang.org/x/text v0.3.4 // indirect
 )
 
-replace github.com/secsy/goftp => github.com/drakkan/goftp v0.0.0-20200916091733-843d4cca4bb2
+replace github.com/secsy/goftp => github.com/drakkan/goftp v0.0.0-20201217084041-93793d4ac54d

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/drakkan/goftp v0.0.0-20200916091733-843d4cca4bb2 h1:aQCoXDfkaeU2/KqIvTZAcVnVmaiGdfrGF9PUnjNVjac=
-github.com/drakkan/goftp v0.0.0-20200916091733-843d4cca4bb2/go.mod h1:K3yqfa64LwJzUpdUWC6b524HO7U7DmBnrJuBjxKSZOQ=
+github.com/drakkan/goftp v0.0.0-20201217084041-93793d4ac54d h1:hIhohhJRpUzEuZj2qExBNzEUAxWk8+ahitt7BEFP1KU=
+github.com/drakkan/goftp v0.0.0-20201217084041-93793d4ac54d/go.mod h1:K3yqfa64LwJzUpdUWC6b524HO7U7DmBnrJuBjxKSZOQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -235,7 +235,7 @@ func TestTLSTransfer(t *testing.T) {
 	rc, response, err = raw.SendCommand("MLSD /")
 	require.NoError(t, err)
 	require.Equal(t, StatusServiceNotAvailable, rc)
-	require.Equal(t, "Unable to open transfer: TLS is required", response)
+	require.Equal(t, "unable to open transfer: TLS is required", response)
 }
 
 func TestDirListingBeforeLogin(t *testing.T) {

--- a/handle_files.go
+++ b/handle_files.go
@@ -159,9 +159,9 @@ func (c *clientHandler) handleCHMOD(params string) {
 
 // https://www.raidenftpd.com/en/raiden-ftpd-doc/help-sitecmd.html (wildcard isn't supported)
 func (c *clientHandler) handleCHOWN(params string) {
-	spl := strings.SplitN(params, " ", 2)
+	spl := strings.SplitN(params, " ", 3)
 
-	if len(spl) < 2 {
+	if len(spl) != 2 {
 		c.writeMessage(StatusSyntaxErrorParameters, "bad command")
 		return
 	}

--- a/handle_files.go
+++ b/handle_files.go
@@ -68,7 +68,7 @@ func (c *clientHandler) transferFile(write bool, append bool) {
 
 		// If this fail, can stop right here and reset the seek position
 		if err != nil {
-			c.writeMessage(550, "Could not access file: "+err.Error())
+			c.writeMessage(StatusActionNotTaken, "Could not access file: "+err.Error())
 			c.ctxRest = 0
 			return
 		}
@@ -200,9 +200,9 @@ func (c *clientHandler) handleCHOWN(params string) {
 // https://learn.akamai.com/en-us/webhelp/netstorage/netstorage-user-guide/
 // GUID-AB301948-C6FF-4957-9291-FE3F02457FD0.html
 func (c *clientHandler) handleSYMLINK(params string) {
-	spl := strings.SplitN(params, " ", 2)
+	spl := strings.SplitN(params, " ", 3)
 
-	if len(spl) < 2 {
+	if len(spl) != 2 {
 		c.writeMessage(StatusSyntaxErrorParameters, "bad command")
 		return
 	}

--- a/handle_files.go
+++ b/handle_files.go
@@ -100,8 +100,8 @@ func (c *clientHandler) transferFile(write bool, append bool) {
 	}
 
 	err = c.doFileTransfer(tr, file, write)
-	if errClose := file.Close(); errClose != nil && err == nil {
-		// FIXME: should we ignore close error if write == false?
+	// we ignore close error for reads
+	if errClose := file.Close(); errClose != nil && err == nil && write {
 		err = errClose
 	}
 

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -250,15 +250,19 @@ func TestSYMLINK(t *testing.T) {
 
 	// Bad syntaxes
 	rc, _, err := raw.SendCommand("SITE SYMLINK")
+	require.NoError(t, err)
 	require.Equal(t, StatusSyntaxErrorNotRecognised, rc, "Should have been refused")
 
 	rc, _, err = raw.SendCommand("SITE SYMLINK ")
+	require.NoError(t, err)
 	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
 
 	rc, _, err = raw.SendCommand("SITE SYMLINK file1")
+	require.NoError(t, err)
 	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
 
 	rc, _, err = raw.SendCommand("SITE SYMLINK file1 file2 file3")
+	require.NoError(t, err)
 	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
 
 	// Creating a bad symlink is authorized

--- a/handle_files_test.go
+++ b/handle_files_test.go
@@ -248,8 +248,21 @@ func TestSYMLINK(t *testing.T) {
 	raw, err := c.OpenRawConn()
 	require.NoError(t, err, "Couldn't open raw connection")
 
-	// Creating a bad clunky is authorized
-	rc, _, err := raw.SendCommand("SITE SYMLINK file3 file4")
+	// Bad syntaxes
+	rc, _, err := raw.SendCommand("SITE SYMLINK")
+	require.Equal(t, StatusSyntaxErrorNotRecognised, rc, "Should have been refused")
+
+	rc, _, err = raw.SendCommand("SITE SYMLINK ")
+	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
+
+	rc, _, err = raw.SendCommand("SITE SYMLINK file1")
+	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
+
+	rc, _, err = raw.SendCommand("SITE SYMLINK file1 file2 file3")
+	require.Equal(t, StatusSyntaxErrorParameters, rc, "Should have been refused")
+
+	// Creating a bad symlink is authorized
+	rc, _, err = raw.SendCommand("SITE SYMLINK file3 file4")
 	require.NoError(t, err)
 	require.Equal(t, StatusOK, rc, "Should have been accepted")
 

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
-	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -327,26 +327,3 @@ func TestFailingFileTransfer(t *testing.T) {
 		require.NoError(t, c.Store("ok", file))
 	})
 }
-
-type testFile struct {
-	afero.File
-}
-
-var errFailClose = errors.New("couldn't close")
-
-var errFailWrite = errors.New("couldn't write")
-
-func (f *testFile) Write(b []byte) (int, error) {
-	if strings.Contains(f.File.Name(), "fail-to-write") {
-		return 0, errFailWrite
-	}
-	return f.File.Write(b)
-}
-
-func (f *testFile) Close() error {
-	if strings.Contains(f.File.Name(), "fail-to-close") {
-		return errFailClose
-	}
-	return f.File.Close()
-}
-

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -311,6 +311,7 @@ func TestFailingFileTransfer(t *testing.T) {
 
 	c, err = goftp.DialConfig(conf, s.Addr())
 	require.NoError(t, err)
+
 	defer func() { require.NoError(t, c.Close()) }()
 
 	t.Run("on write", func(t *testing.T) {


### PR DESCRIPTION
The file transfer logic was a bit broken and could end-up performing two replies to a `STOR` command.

This now correctly reports:
- errors during file transfer & write (was already supported)
- errors during file close and transfer connection close (which is reported as an error)

Please note that this issue probably wasn't introduced by #161, it might have always existed.