### PR TITLE
add settings to disable server STAT and SYST

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -186,4 +186,6 @@ type Settings struct {
 	DisableSite              bool             // Disable SITE command
 	DisableActiveMode        bool             // Disable Active FTP
 	EnableHASH               bool             // Enable support for calculating hash value of files
+	DisableSTAT              bool             // Disable Server STATUS, STAT on files and directories will still work
+	DisableSYST              bool             // Disable SYST
 }

--- a/handle_auth_test.go
+++ b/handle_auth_test.go
@@ -64,6 +64,11 @@ func TestLoginSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusSystemType, rc)
 	require.Equal(t, "UNIX Type: L8", response)
+
+	s.settings.DisableSYST = true
+	rc, response, err = raw.SendCommand("SYST")
+	require.NoError(t, err)
+	require.Equal(t, StatusCommandNotImplemented, rc, response)
 }
 
 func TestLoginFailure(t *testing.T) {

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -40,7 +40,13 @@ func (c *clientHandler) handlePBSZ() error {
 }
 
 func (c *clientHandler) handleSYST() error {
+	if c.server.settings.DisableSYST {
+		c.writeMessage(StatusCommandNotImplemented, "SYST is disabled")
+		return nil
+	}
+
 	c.writeMessage(StatusSystemType, "UNIX Type: L8")
+
 	return nil
 }
 
@@ -80,6 +86,14 @@ func (c *clientHandler) handleSITE() error {
 }
 
 func (c *clientHandler) handleSTATServer() error {
+	if c.server.settings.DisableSTAT {
+		c.writeMessage(StatusCommandNotImplemented, "STAT is disabled")
+		return nil
+	}
+
+	// drakkan(2020-12-17): we don't handle STAT properly,
+	// we should return the status for all the transfers and we should allow
+	// stat while a transfer is in progress, see RFC 959
 	defer c.multilineAnswer(StatusSystemStatus, "Server status")()
 
 	duration := time.Now().UTC().Sub(c.connectedAt)

--- a/handle_misc_test.go
+++ b/handle_misc_test.go
@@ -88,6 +88,12 @@ func TestStat(t *testing.T) {
 	count := strings.Count(str, "\n")
 	require.GreaterOrEqual(t, count, 4)
 	require.NotEqual(t, ' ', str[0])
+
+	s.settings.DisableSTAT = true
+
+	rc, str, err = raw.SendCommand("STAT")
+	require.NoError(t, err)
+	require.Equal(t, StatusCommandNotImplemented, rc, str)
 }
 
 func TestCLNT(t *testing.T) {


### PR DESCRIPTION
Server STAT should be improved from RFC 959

```
STATUS (STAT)

            This command shall cause a status response to be sent over
            the control connection in the form of a reply.  The command
            may be sent during a file transfer (along with the Telnet IP
            and Synch signals--see the Section on FTP Commands) in which
            case the server will respond with the status of the
            operation in progress, or it may be sent between file
            transfers.  In the latter case, the command may have an
            argument field.  If the argument is a pathname, the command
            is analogous to the "list" command except that data shall be
            transferred over the control connection.  If a partial
            pathname is given, the server may respond with a list of
            file names or attributes associated with that specification.
            If no argument is given, the server should return general
            status information about the server FTP process.  This
            should include current values of all transfer parameters and
            the status of connections.
```

we can at least disable it for now, thank you