### PR TITLE
fix data race for methods exposed from ClientContext interface

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -127,10 +127,16 @@ type ClientContext interface {
 	GetClientVersion() string
 
 	// Close closes the connection and disconnects the client.
-	// You can optionally set a status code and a message to
-	// send to the client just before disconnecting it.
-	// Set status code to zero to close without further notice
-	Close(code int, message string) error
+	Close() error
+
+	// HasTLSForControl returns true if the control connection is over TLS
+	HasTLSForControl() bool
+
+	// HasTLSForTransfers returns true if the transfer connection is over TLS
+	HasTLSForTransfers() bool
+
+	// GetLastCommand returns the last received command
+	GetLastCommand() string
 }
 
 // FileTransfer defines the inferface for file transfers.

--- a/handle_auth.go
+++ b/handle_auth.go
@@ -5,7 +5,7 @@ import "fmt"
 
 // Handle the "USER" command
 func (c *clientHandler) handleUSER(param string) error {
-	if c.server.settings.TLSRequired == MandatoryEncryption && !c.controlTLS {
+	if c.server.settings.TLSRequired == MandatoryEncryption && !c.HasTLSForControl() {
 		c.writeMessage(StatusServiceNotAvailable, "TLS is required")
 
 		return nil

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -18,7 +18,7 @@ func (c *clientHandler) handleAUTH(param string) error {
 		c.conn = tls.Server(c.conn, tlsConfig)
 		c.reader = bufio.NewReader(c.conn)
 		c.writer = bufio.NewWriter(c.conn)
-		c.controlTLS = true
+		c.setTLSForControl(true)
 	} else {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Cannot get a TLS config: %v", err))
 	}
@@ -28,7 +28,7 @@ func (c *clientHandler) handleAUTH(param string) error {
 
 func (c *clientHandler) handlePROT(param string) error {
 	// P for Private, C for Clear
-	c.transferTLS = param == "P"
+	c.setTLSForTransfer(param == "P")
 	c.writeMessage(StatusOK, "OK")
 
 	return nil
@@ -185,7 +185,7 @@ func (c *clientHandler) handleNOOP(param string) error {
 }
 
 func (c *clientHandler) handleCLNT(param string) error {
-	c.clnt = param
+	c.setClientVersion(param)
 	c.writeMessage(StatusOK, "Good to know")
 
 	return nil

--- a/transfer_active.go
+++ b/transfer_active.go
@@ -22,21 +22,23 @@ func (c *clientHandler) handlePORT(param string) error {
 	var err error
 	var raddr *net.TCPAddr
 
-	if c.command == "EPRT" {
+	command := c.GetLastCommand()
+
+	if command == "EPRT" {
 		raddr, err = parseEPRTAddr(param)
 	} else { // PORT
 		raddr, err = parsePORTAddr(param)
 	}
 
 	if err != nil {
-		c.writeMessage(StatusSyntaxErrorNotRecognised, fmt.Sprintf("Problem parsing %s: %v", c.command, err))
+		c.writeMessage(StatusSyntaxErrorNotRecognised, fmt.Sprintf("Problem parsing %s: %v", param, err))
 
 		return nil
 	}
 
 	var tlsConfig *tls.Config
 
-	if c.transferTLS || c.server.settings.TLSRequired == ImplicitEncryption {
+	if c.HasTLSForTransfers() || c.server.settings.TLSRequired == ImplicitEncryption {
 		tlsConfig, err = c.server.driver.GetTLSConfig()
 		if err != nil {
 			c.writeMessage(StatusServiceNotAvailable, fmt.Sprintf("Cannot get a TLS config for active connection: %v", err))
@@ -55,7 +57,7 @@ func (c *clientHandler) handlePORT(param string) error {
 
 	c.transferMu.Unlock()
 
-	c.writeMessage(StatusOK, c.command+" command successful")
+	c.writeMessage(StatusOK, command+" command successful")
 
 	return nil
 }

--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -101,10 +101,10 @@ func (c *clientHandler) findListenerWithinPortRange(portRange *PortRange) (*net.
 }
 
 func (c *clientHandler) handlePASV(param string) error {
+	command := c.GetLastCommand()
 	addr, _ := net.ResolveTCPAddr("tcp", ":0")
 
 	var tcpListener *net.TCPListener
-
 	var err error
 
 	portRange := c.server.settings.PassiveTransferPortRange
@@ -125,7 +125,7 @@ func (c *clientHandler) handlePASV(param string) error {
 	// The listener will either be plain TCP or TLS
 	var listener net.Listener
 
-	if c.transferTLS || c.server.settings.TLSRequired == ImplicitEncryption {
+	if c.HasTLSForTransfers() || c.server.settings.TLSRequired == ImplicitEncryption {
 		if tlsConfig, err := c.server.driver.GetTLSConfig(); err == nil {
 			listener = tls.NewListener(tcpListener, tlsConfig)
 		} else {
@@ -146,7 +146,7 @@ func (c *clientHandler) handlePASV(param string) error {
 	}
 
 	// We should rewrite this part
-	if c.command == "PASV" {
+	if command == "PASV" {
 		p1 := p.Port / 256
 		p2 := p.Port - (p1 * 256)
 		quads, err2 := c.getCurrentIP()


### PR DESCRIPTION
Please review, closing the connection seems safe without any additional lock, I also avoided the lock for methods like `ID()`, `RemoteAddr()`,  `LocalAddr()`, they are not modified after the initial connection