### PR TITLE
add support for ASCII transfer mode

### DIFF
--- a/asciiconverter.go
+++ b/asciiconverter.go
@@ -20,7 +20,7 @@ type asciiConverter struct {
 }
 
 func newASCIIConverter(r io.Reader, mode convertMode) *asciiConverter {
-	reader := bufio.NewReader(r)
+	reader := bufio.NewReaderSize(r, 4096)
 
 	return &asciiConverter{
 		reader:    reader,

--- a/asciiconverter.go
+++ b/asciiconverter.go
@@ -1,0 +1,86 @@
+// Package ftpserver provides all the tools to build your own FTP server: The core library and the driver.
+package ftpserver
+
+import (
+	"bufio"
+	"io"
+)
+
+type convertMode int
+
+const (
+	convertModeToCRLF convertMode = iota
+	convertModeToLF
+)
+
+type asciiConverter struct {
+	reader    *bufio.Reader
+	mode      convertMode
+	remaining []byte
+}
+
+func newASCIIConverter(r io.Reader, mode convertMode) *asciiConverter {
+	reader := bufio.NewReader(r)
+
+	return &asciiConverter{
+		reader:    reader,
+		mode:      mode,
+		remaining: nil,
+	}
+}
+
+func (c *asciiConverter) Read(p []byte) (n int, err error) {
+	var data []byte
+
+	if len(c.remaining) > 0 {
+		data = c.remaining
+		c.remaining = nil
+	} else {
+		data, _, err = c.reader.ReadLine()
+		if err != nil {
+			return
+		}
+	}
+
+	n = len(data)
+	if n > 0 {
+		maxSize := len(p) - 2
+		if n > maxSize {
+			copy(p, data[:maxSize])
+			c.remaining = data[maxSize:]
+
+			return maxSize, nil
+		}
+
+		copy(p[:n], data[:n])
+	}
+
+	// we can have a partial read if the line is too long
+	// or a trailing line without a line ending, so we check
+	// the last byte to decide if we need to add a line ending.
+	// This will also ensure that a file without line endings
+	// will remain unchanged.
+	// Please note that a binary file will likely contain
+	// newline chars so it will be still corrupted if the
+	// client transfers it in ASCII mode
+	err = c.reader.UnreadByte()
+	if err != nil {
+		return
+	}
+
+	lastByte, err := c.reader.ReadByte()
+
+	if err == nil && lastByte == '\n' {
+		switch c.mode {
+		case convertModeToCRLF:
+			p[n] = '\r'
+			p[n+1] = '\n'
+			n += 2
+		case convertModeToLF:
+			p[n] = '\n'
+			n++
+		}
+	}
+
+	return n, err
+}

--- a/asciiconverter_test.go
+++ b/asciiconverter_test.go
@@ -1,0 +1,67 @@
+package ftpserver
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestASCIIConvert(t *testing.T) {
+	lines := []byte("line1\r\nline2\r\n\r\nline4")
+	src := bytes.NewBuffer(lines)
+	dst := bytes.NewBuffer(nil)
+	c := newASCIIConverter(src, convertModeToLF)
+	_, err := io.Copy(dst, c)
+	require.NoError(t, err)
+	require.Equal(t, []byte("line1\nline2\n\nline4"), dst.Bytes())
+
+	lines = []byte("line1\nline2\n\nline4")
+	dst = bytes.NewBuffer(nil)
+	c = newASCIIConverter(bytes.NewBuffer(lines), convertModeToCRLF)
+	_, err = io.Copy(dst, c)
+	require.NoError(t, err)
+	require.Equal(t, []byte("line1\r\nline2\r\n\r\nline4"), dst.Bytes())
+
+	// test a src buffers without line endings, it must remain unchanged
+	buf := make([]byte, 131072)
+	for j := range buf {
+		buf[j] = 66
+	}
+
+	dst = bytes.NewBuffer(nil)
+	c = newASCIIConverter(bytes.NewBuffer(buf), convertModeToCRLF)
+	_, err = io.Copy(dst, c)
+	require.NoError(t, err)
+	require.Equal(t, buf, dst.Bytes())
+}
+
+func BenchmarkASCIIConverter(b *testing.B) {
+	linesCRLF := []byte("line1\r\nline2\r\n\r\nline4")
+	linesLF := []byte("line1\nline2\n\nline4")
+
+	readerCRLF := bytes.NewBuffer(nil)
+	readerLF := bytes.NewBuffer(nil)
+
+	for i := 0; i < 100000; i++ {
+		_, err := readerCRLF.Write(linesCRLF)
+		panicOnError(err)
+
+		_, err = readerLF.Write(linesLF)
+		panicOnError(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		c := newASCIIConverter(readerCRLF, convertModeToLF)
+		_, err := io.Copy(ioutil.Discard, c)
+		panicOnError(err)
+
+		c = newASCIIConverter(readerLF, convertModeToCRLF)
+		_, err = io.Copy(ioutil.Discard, c)
+		panicOnError(err)
+	}
+}

--- a/consts.go
+++ b/consts.go
@@ -49,6 +49,7 @@ const (
 	StatusSyntaxErrorParameters    = 501 // RFC 959, 4.2.1
 	StatusCommandNotImplemented    = 502 // RFC 959, 4.2.1
 	StatusBadCommandSequence       = 503 // RFC 959, 4.2.1
+	StatusNotImplementedParam      = 504 // RFC 959, 4.2.1
 	StatusNotLoggedIn              = 530 // RFC 959, 4.2.1
 	StatusActionNotTaken           = 550 // RFC 959, 4.2.1
 	StatusActionAborted            = 552 // RFC 959, 4.2.1

--- a/driver.go
+++ b/driver.go
@@ -195,4 +195,5 @@ type Settings struct {
 	DisableSTAT              bool             // Disable Server STATUS, STAT on files and directories will still work
 	DisableSYST              bool             // Disable SYST
 	EnableCOMB               bool             // Enable COMB support
+	DefaultTransferType      TransferType     // Transfer type to use if the client don't send the TYPE command
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -34,7 +34,9 @@ func NewTestServerWithDriver(t *testing.T, driver *TestServerDriver) *FtpServer 
 	t.Parallel()
 
 	if driver.Settings == nil {
-		driver.Settings = &Settings{}
+		driver.Settings = &Settings{
+			DefaultTransferType: TransferTypeBinary,
+		}
 	}
 
 	if driver.Settings.ListenAddr == "" {

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -259,12 +259,14 @@ func (c *clientHandler) handleFEAT(param string) error {
 
 func (c *clientHandler) handleTYPE(param string) error {
 	switch param {
-	case "I":
+	case "I", "L8":
+		c.currentTransferType = TransferTypeBinary
 		c.writeMessage(StatusOK, "Type set to binary")
-	case "A":
-		c.writeMessage(StatusOK, "ASCII isn't properly supported: https://github.com/fclairamb/ftpserverlib/issues/86")
+	case "A", "L7":
+		c.currentTransferType = TransferTypeASCII
+		c.writeMessage(StatusOK, "Type set to ASCII")
 	default:
-		c.writeMessage(StatusSyntaxErrorNotRecognised, "Not understood")
+		c.writeMessage(StatusNotImplementedParam, "Unsupported transfer type")
 	}
 
 	return nil

--- a/handle_misc_test.go
+++ b/handle_misc_test.go
@@ -299,5 +299,5 @@ func TestTYPE(t *testing.T) {
 
 	rc, _, err = raw.SendCommand("TYPE wrong")
 	require.NoError(t, err)
-	require.Equal(t, StatusSyntaxErrorNotRecognised, rc)
+	require.Equal(t, StatusNotImplementedParam, rc)
 }

--- a/server.go
+++ b/server.go
@@ -271,7 +271,7 @@ func (server *FtpServer) clientArrival(conn net.Conn) {
 	server.clientCounter++
 	id := server.clientCounter
 
-	c := server.newClientHandler(conn, id)
+	c := server.newClientHandler(conn, id, server.settings.DefaultTransferType)
 	go c.HandleCommands()
 
 	c.logger.Info("Client connected", "clientIp", conn.RemoteAddr())


### PR DESCRIPTION
Hi,

I don't like ASCII mode but it's a basic piece of RFC 959 so I think we should support it.

This implementation is based on pyftpdlib, please search `self._current_type` [here](https://github.com/giampaolo/pyftpdlib/blob/master/pyftpdlib/handlers.py).

For the converter I evaluated [this library](https://github.com/andybalholm/crlf) too, if you change the included benchmark you can see that it is slower than the proposed implementation, for example using this code:

```
    c := crlf.NewReader(readerCRLF)
    _, err := io.Copy(ioutil.Discard, c)
    panicOnError(err)
```

you have this result:

```
BenchmarkASCIIConverter-12          802696          1309 ns/op        8368 B/op           4 allocs/op
```

replacing it with this code:

```
    c := newASCIIConverter(readerCRLF, convertModeToLF)
    _, err := io.Copy(ioutil.Discard, c)
    panicOnError(err)
```

the result is this one:

```
BenchmarkASCIIConverter-12         1611764           775 ns/op        4255 B/op           3 allocs/op
```

I did some testing using filezilla as client and some big text files such as the ones [here](https://corpus.canterbury.ac.nz/descriptions/)

I also tested the file obtained using this command:

```
yes "Some text entry here. This will be on each line..." | head -n 10000000 > bigfile.txt
```

it seems fine, however more testing would be better :) thank you!