### PR TITLE
fix denial of service

### DIFF
--- a/handle_misc.go
+++ b/handle_misc.go
@@ -16,7 +16,7 @@ func (c *clientHandler) handleAUTH(param string) error {
 	if tlsConfig, err := c.server.driver.GetTLSConfig(); err == nil {
 		c.writeMessage(StatusAuthAccepted, "AUTH command ok. Expecting TLS Negotiation.")
 		c.conn = tls.Server(c.conn, tlsConfig)
-		c.reader = bufio.NewReader(c.conn)
+		c.reader = bufio.NewReaderSize(c.conn, maxCommandSize)
 		c.writer = bufio.NewWriter(c.conn)
 		c.setTLSForControl(true)
 	} else {


### PR DESCRIPTION
if a client sends data without `\n`, we have no read limit.

The default buffer size for a bufio reader is 4096 but  `ReadString('\n')` will try to read until `\n` in any case, so replace it with `ReadLine()`. This way if the line was too long for the buffer then `isPrefix` is set and the beginning of the line is returned.

Please try the included `TestDOS` with the old code to understand the issue, thank you