### PR TITLE
immediately close the control connection if a client send a line too …

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -336,9 +336,12 @@ func (c *clientHandler) HandleCommands() {
 		lineSlice, isPrefix, err := c.reader.ReadLine()
 
 		if isPrefix {
+			err = c.conn.Close()
+
 			if c.debug {
 				c.logger.Warn("Received line too long, disconnecting client",
-					"size", len(lineSlice))
+					"line_size", len(lineSlice),
+					"close_err", err)
 			}
 
 			return


### PR DESCRIPTION
…long

c.end() only close the transfer connection

Sorry I only noticed this now while doing some manual tests with sftpgo