### PR TITLE
ensure to always close the control connection

### DIFF
--- a/client_handler_test.go
+++ b/client_handler_test.go
@@ -135,6 +135,35 @@ func TestTLSMethods(t *testing.T) {
 	})
 }
 
+func TestConnectionNotAllowed(t *testing.T) {
+	driver := &TestServerDriver{
+		Debug:          true,
+		CloseOnConnect: true,
+	}
+	s := NewTestServerWithDriver(t, driver)
+
+	conn, err := net.DialTimeout("tcp", s.Addr(), 5*time.Second)
+	require.NoError(t, err)
+
+	defer func() {
+		err = conn.Close()
+		require.NoError(t, err)
+	}()
+
+	buf := make([]byte, 128)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+
+	response := string(buf[:n])
+	require.Equal(t, "500 TEST Server\r\n", response)
+
+	_, err = conn.Write([]byte("NOOP\r\n"))
+	require.NoError(t, err)
+
+	_, err = conn.Read(buf)
+	require.Error(t, err)
+}
+
 func TestCloseConnection(t *testing.T) {
 	driver := &TestServerDriver{
 		Debug: true,


### PR DESCRIPTION
if ClientConnected returns an error, the control connection is not 
closed so a client could keep it open indefinitely.

Closing the control connection within the `end()` method ensures that
the connection is always closed. 

If the connection was already closed client side we get the error 
`use of closed network connection`, this error should not cause 
any issue