### PR TITLE
fix: Skipping IPv6 if it's not supported

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -61,13 +61,13 @@ func NewTestServerWithDriver(t *testing.T, driver *TestServerDriver) *FtpServer 
 		)
 	}
 
-	t.Cleanup(func() {
-		mustStopServer(s)
-	})
-
 	if err := s.Listen(); err != nil {
 		return nil
 	}
+
+	t.Cleanup(func() {
+		mustStopServer(s)
+	})
 
 	go func() {
 		if err := s.Serve(); err != nil && err != io.EOF {

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -169,6 +169,10 @@ func TestTransferIPv6(t *testing.T) {
 		},
 	)
 
+	if s == nil {
+		t.Skip("IPv6 is not supported here")
+	}
+
 	t.Run("active", func(t *testing.T) { testTransferOnConnection(t, s, true, false, false) })
 	t.Run("passive", func(t *testing.T) { testTransferOnConnection(t, s, false, false, false) })
 }


### PR DESCRIPTION
It has been blocking tests on gocover.io