### PR TITLE
driver: store the TLS connection verification status

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -85,6 +85,7 @@ type clientHandler struct {
 	debug               bool            // Show debugging info on the server side
 	transferTLS         bool            // Use TLS for transfer connection
 	controlTLS          bool            // Use TLS for control connection
+	verifiedTLS         bool            // Is true if the MainDriverExtensionTLSVerifier was called and returned no error
 	selectedHashAlgo    HASHAlgo        // algorithm used when we receive the HASH command
 	logger              log.Logger      // Client handler logging
 	currentTransferType TransferType    // current transfer type
@@ -236,6 +237,21 @@ func (c *clientHandler) setLastCommand(cmd string) {
 	defer c.paramsMutex.Unlock()
 
 	c.command = cmd
+}
+
+// IsTLSVerified returns the TLS connection verification status
+func (c *clientHandler) IsTLSVerified() bool {
+	c.paramsMutex.RLock()
+	defer c.paramsMutex.RUnlock()
+
+	return c.verifiedTLS
+}
+
+func (c *clientHandler) setTLSVerified(value bool) {
+	c.paramsMutex.Lock()
+	defer c.paramsMutex.Unlock()
+
+	c.verifiedTLS = value
 }
 
 func (c *clientHandler) closeTransfer() error {

--- a/driver.go
+++ b/driver.go
@@ -147,6 +147,9 @@ type ClientContext interface {
 
 	// GetLastCommand returns the last received command
 	GetLastCommand() string
+
+	// IsTLSVerified returns true if the TLS control connection was successfully verified
+	IsTLSVerified() bool
 }
 
 // FileTransfer defines the inferface for file transfers.

--- a/driver_test.go
+++ b/driver_test.go
@@ -260,6 +260,7 @@ func (driver *TestServerDriver) GetClientsInfo() map[uint32]interface{} {
 		ccInfo["hasTLSForTransfers"] = cc.HasTLSForTransfers()
 		ccInfo["lastCommand"] = cc.GetLastCommand()
 		ccInfo["debug"] = cc.Debug()
+		ccInfo["isTLSVerified"] = cc.IsTLSVerified()
 
 		info[cc.ID()] = ccInfo
 	}

--- a/handle_auth.go
+++ b/handle_auth.go
@@ -18,6 +18,8 @@ func (c *clientHandler) handleUSER(param string) error {
 			if tlsConn, ok := c.conn.(*tls.Conn); ok {
 				driver, err := verifier.VerifyConnection(c, param, tlsConn)
 
+				c.setTLSVerified(err == nil)
+
 				if err != nil {
 					c.writeMessage(StatusNotLoggedIn, fmt.Sprintf("TLS verification failed: %v", err))
 					c.disconnect()


### PR DESCRIPTION
Hi,

I'm improving mutual TLS within SFTPGo. Currently SFTPGo supports client certificate + password. To enable this mode you have to globaly require TLS certificate validation, so basically all clients are required to authenticate using a valid TLS certificate and a password.

After my last patch to ftpserverlib I can enable a smarter way for mutual TLS, I can allow both mutual TLS and normal TLS connections and allow to set for each user whether they should be authenticated using a TLS cert, a password or a TLS cert and a password.

For the TLS cert + password case I have to store the TLS verification status somewhere and disallow password authentication if a TLS certificate was not successufully verified (when the client sends the `USER` command). I can store this status inside SFTPGo itself but maybe is more convenient storing it directly within the ftpserverlib ClientContext. 

@fclairamb , please let me know what do you think about. If you don't want another property I have no problem to store the status inside SFTPGo, thank you.