### PR TITLE
PASV: make sure that the passive IP is valid

### DIFF
--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -56,16 +56,17 @@ func (c *clientHandler) getCurrentIP() ([]string, error) {
 		}
 	}
 
-	parsedId := net.ParseIP(ip)
-	if parsedId == nil {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
 		return nil, fmt.Errorf("invalid passive IP %#v", ip)
 	}
-	parsedId = parsedId.To4()
-	if parsedId == nil {
+
+	parsedIP = parsedIP.To4()
+	if parsedIP == nil {
 		return nil, fmt.Errorf("invalid IPv4 passive IP %#v", ip)
 	}
 
-	return strings.Split(parsedId.String(), "."), nil
+	return strings.Split(parsedIP.String(), "."), nil
 }
 
 // ErrNoAvailableListeningPort is returned when no port could be found to accept incoming connection

--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -56,7 +56,16 @@ func (c *clientHandler) getCurrentIP() ([]string, error) {
 		}
 	}
 
-	return strings.Split(ip, "."), nil
+	parsedId := net.ParseIP(ip)
+	if parsedId == nil {
+		return nil, fmt.Errorf("invalid passive IP %#v", ip)
+	}
+	parsedId = parsedId.To4()
+	if parsedId == nil {
+		return nil, fmt.Errorf("invalid IPv4 passive IP %#v", ip)
+	}
+
+	return strings.Split(parsedId.String(), "."), nil
 }
 
 // ErrNoAvailableListeningPort is returned when no port could be found to accept incoming connection

--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -37,6 +37,14 @@ type passiveTransferHandler struct {
 	logger      log.Logger       // Logger
 }
 
+type ipValidationError struct {
+	error string
+}
+
+func (e *ipValidationError) Error() string {
+	return e.error
+}
+
 func (c *clientHandler) getCurrentIP() ([]string, error) {
 	// Provide our external IP address so the ftp client can connect back to us
 	ip := c.server.settings.PublicHost
@@ -58,12 +66,12 @@ func (c *clientHandler) getCurrentIP() ([]string, error) {
 
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
-		return nil, fmt.Errorf("invalid passive IP %#v", ip)
+		return nil, &ipValidationError{error: fmt.Sprintf("invalid passive IP %#v", ip)}
 	}
 
 	parsedIP = parsedIP.To4()
 	if parsedIP == nil {
-		return nil, fmt.Errorf("invalid IPv4 passive IP %#v", ip)
+		return nil, &ipValidationError{error: fmt.Sprintf("invalid IPv4 passive IP %#v", ip)}
 	}
 
 	return strings.Split(parsedIP.String(), "."), nil


### PR DESCRIPTION
an invalid IPv4 address will cause PASV handling crashes.

Fixes #235