### PR TITLE
CWD: prevent changing directory to a regular file

### DIFF
--- a/handle_dirs.go
+++ b/handle_dirs.go
@@ -25,9 +25,13 @@ func (c *clientHandler) absPath(p string) string {
 func (c *clientHandler) handleCWD(param string) error {
 	p := c.absPath(param)
 
-	if stat, err := c.driver.Stat(p); err == nil && !stat.Mode().IsRegular() {
-		c.SetPath(p)
-		c.writeMessage(StatusFileOK, fmt.Sprintf("CD worked on %s", p))
+	if stat, err := c.driver.Stat(p); err == nil {
+		if stat.IsDir() {
+			c.SetPath(p)
+			c.writeMessage(StatusFileOK, fmt.Sprintf("CD worked on %s", p))
+		} else {
+			c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Can't change directory to %s: Not a Directory", p))
+		}
 	} else {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("CD issue: %v", err))
 	}

--- a/handle_dirs.go
+++ b/handle_dirs.go
@@ -25,7 +25,7 @@ func (c *clientHandler) absPath(p string) string {
 func (c *clientHandler) handleCWD(param string) error {
 	p := c.absPath(param)
 
-	if _, err := c.driver.Stat(p); err == nil {
+	if stat, err := c.driver.Stat(p); err == nil && !stat.Mode().IsRegular() {
 		c.SetPath(p)
 		c.writeMessage(StatusFileOK, fmt.Sprintf("CD worked on %s", p))
 	} else {

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -151,8 +151,9 @@ func TestCWDToRegularFile(t *testing.T) {
 	// Creating a tiny file
 	ftpUpload(t, c, createTemporaryFile(t, 10), "file.txt")
 
-	rc, _, err := raw.SendCommand("CWD /file.txt")
+	rc, msg, err := raw.SendCommand("CWD /file.txt")
 	require.NoError(t, err)
+	require.Equal(t, `Can't change directory to /file.txt: Not a Directory`, msg)
 	require.Equal(t, StatusActionNotTaken, rc, "We shouldn't have been able to CWD to a regular file")
 }
 

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -126,6 +126,36 @@ func TestDirHandling(t *testing.T) {
 	require.Error(t, err, "We shouldn't have been able to ftpDelete known again")
 }
 
+func TestCWDToRegularFile(t *testing.T) {
+	s := NewTestServer(t, true)
+	conf := goftp.Config{
+		User:     authUser,
+		Password: authPass,
+	}
+
+	c, err := goftp.DialConfig(conf, s.Addr())
+	require.NoError(t, err, "Couldn't connect")
+
+	defer func() { panicOnError(c.Close()) }()
+
+	// Getwd will send a PWD command
+	p, err := c.Getwd()
+	require.NoError(t, err)
+	require.Equal(t, "/", p, "Bad path")
+
+	raw, err := c.OpenRawConn()
+	require.NoError(t, err, "Couldn't open raw connection")
+
+	defer func() { require.NoError(t, raw.Close()) }()
+
+	// Creating a tiny file
+	ftpUpload(t, c, createTemporaryFile(t, 10), "file.txt")
+
+	rc, _, err := raw.SendCommand("CWD /file.txt")
+	require.NoError(t, err)
+	require.Equal(t, StatusActionNotTaken, rc, "We shouldn't have been able to CWD to a regular file")
+}
+
 func TestMkdirRmDir(t *testing.T) {
 	s := NewTestServer(t, true)
 	conf := goftp.Config{


### PR DESCRIPTION
From my testing, PHP's is_file and is_dir functions, when given an FTP URL (ftp://user:pass@host/file.txt), attempts to determine if a path is a directory or not by the ability to CWD to that path.