### PR TITLE
Fix LIST command for file

### DIFF
--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -48,6 +48,15 @@ func TestDirListing(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, contents, 1)
 	require.Equal(t, DirKnown, contents[0].Name())
+
+	// LIST also works for filePath
+	var fileName = "testfile.ext"
+	ftpUpload(t, c, createTemporaryFile(t, 10), fileName)
+
+	fileContents, err := c.ReadDir(fileName)
+	require.NoError(t, err)
+	require.Len(t, fileContents, 1)
+	require.Equal(t, fileName, fileContents[0].Name())
 }
 
 func TestDirListingPathArg(t *testing.T) {

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -51,6 +51,7 @@ func TestDirListing(t *testing.T) {
 
 	// LIST also works for filePath
 	var fileName = "testfile.ext"
+
 	ftpUpload(t, c, createTemporaryFile(t, 10), fileName)
 
 	fileContents, err := c.ReadDir(fileName)

--- a/handle_dirs_test.go
+++ b/handle_dirs_test.go
@@ -52,6 +52,9 @@ func TestDirListing(t *testing.T) {
 	// LIST also works for filePath
 	var fileName = "testfile.ext"
 
+	_, err = c.ReadDir(fileName)
+	require.Error(t, err, "LIST for not existing filePath must fail")
+
 	ftpUpload(t, c, createTemporaryFile(t, 10), fileName)
 
 	fileContents, err := c.ReadDir(fileName)
@@ -504,13 +507,16 @@ func TestMLSDAndNLSTFilePathError(t *testing.T) {
 
 	defer func() { panicOnError(c.Close()) }()
 
+	// MLSD shouldn't work for filePaths
 	var fileName = "testfile.ext"
+
+	_, err = c.ReadDir(fileName)
+	require.Error(t, err, "MLSD for not existing filePath must fail")
 
 	ftpUpload(t, c, createTemporaryFile(t, 10), fileName)
 
-	// MLSD shouldn't work for filePaths
 	_, err = c.ReadDir(fileName)
-	require.Error(t, err, "MLSD is enabled MLSD for filePath must fail")
+	require.Error(t, err, "MLSD is enabled, MLSD for filePath must fail")
 
 	// NLST shouldn't work for filePath
 	raw, err := c.OpenRawConn()
@@ -526,5 +532,5 @@ func TestMLSDAndNLSTFilePathError(t *testing.T) {
 	require.Equal(t, StatusFileActionNotTaken, rc, response)
 
 	_, _, err = raw.ReadResponse()
-	require.Error(t, err, "MLSD is enabled MLSD for filePath must fail")
+	require.Error(t, err, "NLST for filePath must fail")
 }


### PR DESCRIPTION
now returns a list with a single file for "LIST filePath".
Using modified getFileList function with filePathAllowed = true.

Fixes [#240](https://github.com/fclairamb/ftpserverlib/issues/240)