### PR TITLE
notify a transfer error if the data connection cannot be opened

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -422,6 +422,7 @@ func (c *clientHandler) handleCommand(line string) {
 		}
 
 		if cmdDesc == nil {
+			c.logger.Warn("Unknown command", "command", command)
 			c.setLastCommand(command)
 			c.writeMessage(StatusSyntaxErrorNotRecognised, fmt.Sprintf("Unknown command %#v", command))
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -111,6 +111,7 @@ type TestClientDriver struct {
 
 type testFile struct {
 	afero.File
+	errTransfer error
 }
 
 var (
@@ -177,6 +178,11 @@ func (f *testFile) Readdir(count int) ([]os.FileInfo, error) {
 	}
 
 	return f.File.Readdir(count)
+}
+
+// TransferError implements the FileTransferError interface
+func (f *testFile) TransferError(err error) {
+	f.errTransfer = err
 }
 
 // NewTestClientDriver creates a client driver

--- a/handle_files.go
+++ b/handle_files.go
@@ -100,6 +100,9 @@ func (c *clientHandler) transferFile(write bool, append bool, param, info string
 
 	tr, err := c.TransferOpen(info)
 	if err != nil {
+		if fileTransferError, ok := file.(FileTransferError); ok {
+			fileTransferError.TransferError(err)
+		}
 		// an error is already returned to the FTP client
 		// we can stop right here and close the file ignoring close error if any
 		c.closeUnchecked(file)


### PR DESCRIPTION
If ftpserverlib is unable to open the transfer connection we endup with a 0 bytes file and no error. This patch notify the error using the `FileTransferError` interface. This way SFTPGo can detect the error and take the appropriate (configured) actions instead of reporting a successfull 0 bytes upload.

I also added a log for unknow commands. This avoid to enable debugging only to find that a client sent a wrong/unsupported command