### PR TITLE
data connection stealing and bounce attack mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're interested in a fully featured FTP server, you should use [sftpgo](htt
  * Active socket connections (PORT and EPRT commands)
  * IPv6 support (EPSV + EPRT)
  * Small memory footprint
- * Clean code: No sleep, no panic, no global sync (only around control/transfer connection per client) 
+ * Clean code: No sleep, no panic, no global sync (only around control/transfer connection per client)
  * Uses only the standard library except for:
    * [afero](https://github.com/spf13/afero) for generic file systems handling
    * [go-kit log](https://github.com/go-kit/kit/tree/master/log) (optional) for logging
@@ -48,7 +48,7 @@ If you're interested in a fully featured FTP server, you should use [sftpgo](htt
 The easiest way to test this library is to use [ftpserver](https://github.com/fclairamb/ftpserver).
 
 ## The driver
-The simplest way to get a good understanding of how the driver shall be implemented, you can have a look at the [tests driver](https://github.com/fclairamb/ftpserverlib/blob/master/driver_test.go). 
+The simplest way to get a good understanding of how the driver shall be implemented, you can have a look at the [tests driver](https://github.com/fclairamb/ftpserverlib/blob/master/driver_test.go).
 
 ### The base API
 
@@ -142,6 +142,13 @@ type Settings struct {
 	DisableSYST              bool             // Disable SYST
 	EnableCOMB               bool             // Enable COMB support
 	DefaultTransferType      TransferType     // Transfer type to use if the client don't send the TYPE command
+	// ActiveConnectionsCheck defines the security requirements for active connections
+	ActiveConnectionsCheck DataConnectionRequirement
+	// PasvConnectionsCheck defines the security requirements for passive connections
+	PasvConnectionsCheck DataConnectionRequirement
+	// DataConnectionTrustedNetworks defines trusted networks for IPMatchRelaxed and
+	// IPMatchTrusted security requirements
+	DataConnectionTrustedNetworks []*net.IPNet
 }
 ```
 
@@ -193,7 +200,7 @@ type ClientDriverExtensionHasher interface {
 
 I wanted to make a system which would accept files through FTP and redirect them to something else. Go seemed like the obvious choice and it seemed there was a lot of libraries available but it turns out none of them were in a useable state.
 
-* [micahhausler/go-ftp](https://github.com/micahhausler/go-ftp) is a  minimalistic implementation 
+* [micahhausler/go-ftp](https://github.com/micahhausler/go-ftp) is a  minimalistic implementation
 * [shenfeng/ftpd.go](https://github.com/shenfeng/ftpd.go) is very basic and 4 years old.
 * [yob/graval](https://github.com/yob/graval) is 3 years old and “experimental”.
 * [goftp/server](https://github.com/goftp/server) seemed OK but I couldn't use it on both Filezilla and the MacOs ftp client.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,6 @@ type Settings struct {
 	ActiveConnectionsCheck DataConnectionRequirement
 	// PasvConnectionsCheck defines the security requirements for passive connections
 	PasvConnectionsCheck DataConnectionRequirement
-	// DataConnectionTrustedNetworks defines trusted networks for IPMatchRelaxed and
-	// IPMatchTrusted security requirements
-	DataConnectionTrustedNetworks []*net.IPNet
 }
 ```
 

--- a/client_handler.go
+++ b/client_handler.go
@@ -635,6 +635,81 @@ func (c *clientHandler) TransferClose(err error) {
 	}
 }
 
+func (c *clientHandler) isDataConnectionIPTrusted(dataConnIP net.IP) bool {
+	for _, cidrNet := range c.server.settings.DataConnectionTrustedNetworks {
+		if cidrNet.Contains(dataConnIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *clientHandler) checkDataConnectionRequirement(dataConnIP net.IP, channelType DataChannel) error {
+	var requirement DataConnectionRequirement
+
+	switch channelType {
+	case DataChannelActive:
+		requirement = c.server.settings.ActiveConnectionsCheck
+	case DataChannelPassive:
+		requirement = c.server.settings.PasvConnectionsCheck
+	}
+
+	switch requirement {
+	case IPMatchRequired, IPMatchRelaxed:
+		if requirement == IPMatchRelaxed {
+			if c.isDataConnectionIPTrusted(dataConnIP) {
+				return nil
+			}
+		}
+
+		controlConnIP, err := getIPFromRemoteAddr(c.RemoteAddr())
+		if err != nil {
+			return err
+		}
+
+		if !controlConnIP.Equal(dataConnIP) {
+			return &ipValidationError{error: fmt.Sprintf("data connection ip address %v "+
+				"does not match control connection ip address %v",
+				dataConnIP, controlConnIP)}
+		}
+
+		return nil
+
+	case IPMatchTrusted:
+		if !c.isDataConnectionIPTrusted(dataConnIP) {
+			return &ipValidationError{error: fmt.Sprintf("data connection ip address %v "+
+				"is not trusted and strict checking is configured",
+				dataConnIP)}
+		}
+
+		return nil
+	case IPMatchDisabled:
+		return nil
+	default:
+		return &ipValidationError{error: fmt.Sprintf("unhandled data connection requirement: %v",
+			requirement)}
+	}
+}
+
+func getIPFromRemoteAddr(remoteAddr net.Addr) (net.IP, error) {
+	if remoteAddr == nil {
+		return nil, &ipValidationError{error: "nil remote address"}
+	}
+
+	ip, _, err := net.SplitHostPort(remoteAddr.String())
+	if err != nil {
+		return nil, err
+	}
+
+	remoteIP := net.ParseIP(ip)
+	if remoteIP == nil {
+		return nil, &ipValidationError{error: fmt.Sprintf("invalid remote IP: %v", ip)}
+	}
+
+	return remoteIP, nil
+}
+
 func parseLine(line string) (string, string) {
 	params := strings.SplitN(line, " ", 2)
 	if len(params) == 1 {

--- a/client_handler_test.go
+++ b/client_handler_test.go
@@ -344,3 +344,197 @@ func TestUnknownCommand(t *testing.T) {
 	require.Equal(t, StatusSyntaxErrorNotRecognised, rc)
 	require.Equal(t, fmt.Sprintf("Unknown command %#v", cmd), response)
 }
+
+// testNetConn implements net.Conn interface
+type testNetConn struct {
+	remoteAddr net.Addr
+}
+
+func (*testNetConn) Read(b []byte) (n int, err error) {
+	return
+}
+
+func (*testNetConn) Write(b []byte) (n int, err error) {
+	return
+}
+
+func (*testNetConn) Close() error {
+	return nil
+}
+
+func (*testNetConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (c *testNetConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (*testNetConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (*testNetConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (*testNetConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// testNetListener implements net.Listener interface
+type testNetListener struct {
+	conn net.Conn
+}
+
+func (l *testNetListener) Accept() (net.Conn, error) {
+	if l.conn != nil {
+		return l.conn, nil
+	}
+
+	return nil, &net.AddrError{}
+}
+
+func (*testNetListener) Close() error {
+	return nil
+}
+
+func (*testNetListener) Addr() net.Addr {
+	return nil
+}
+
+func TestDataConnectionRequirements(t *testing.T) {
+	_, trustedCIDR, err := net.ParseCIDR("192.168.1.0/24")
+	require.NoError(t, err)
+
+	controlConnIP := net.ParseIP("192.168.1.1")
+
+	c := clientHandler{
+		conn: &testNetConn{
+			remoteAddr: &net.TCPAddr{IP: controlConnIP, Port: 21},
+		},
+		server: &FtpServer{
+			settings: &Settings{
+				PasvConnectionsCheck:          IPMatchRequired,
+				ActiveConnectionsCheck:        IPMatchRequired,
+				DataConnectionTrustedNetworks: []*net.IPNet{trustedCIDR},
+			},
+		},
+	}
+
+	err = c.checkDataConnectionRequirement(controlConnIP, DataChannelPassive)
+	assert.NoError(t, err) // ip match
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"), DataChannelActive)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "does not match control connection ip address")
+	}
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"), DataChannelPassive)
+	assert.Error(t, err) // the IP is in a trusted network but we configured IPMatchRequired
+
+	c.server.settings.PasvConnectionsCheck = IPMatchRelaxed
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"), DataChannelPassive)
+	assert.NoError(t, err)
+
+	c.server.settings.PasvConnectionsCheck = IPMatchTrusted
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"), DataChannelPassive)
+	assert.NoError(t, err)
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.0.2"), DataChannelPassive)
+	assert.Error(t, err) // IP is not trusted
+
+	c.server.settings.DataConnectionTrustedNetworks = nil
+	c.server.settings.PasvConnectionsCheck = IPMatchRequired
+
+	c.conn = &testNetConn{
+		remoteAddr: &net.IPAddr{IP: controlConnIP},
+	}
+
+	err = c.checkDataConnectionRequirement(controlConnIP, DataChannelPassive)
+	assert.Error(t, err)
+
+	// nil remote address
+	c.conn = &testNetConn{}
+	err = c.checkDataConnectionRequirement(controlConnIP, DataChannelActive)
+	assert.Error(t, err)
+
+	// invalid IP
+	c.conn = &testNetConn{
+		remoteAddr: &net.TCPAddr{IP: nil, Port: 21},
+	}
+
+	err = c.checkDataConnectionRequirement(controlConnIP, DataChannelPassive)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid remote IP")
+	}
+
+	// invalid setting
+	c.server.settings.PasvConnectionsCheck = 100
+	err = c.checkDataConnectionRequirement(controlConnIP, DataChannelPassive)
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "unhandled data connection requirement")
+	}
+}
+
+/*func TestDataConnectionRequirements(t *testing.T) {
+	_, trustedCIDR, err := net.ParseCIDR("192.168.1.0/24")
+	require.NoError(t, err)
+
+	c := clientHandler{
+		conn: &testNetConn{
+			remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 21},
+		},
+		server: &FtpServer{
+			settings: &Settings{
+				DataConnectionCheck:           IPMatchRequired,
+				DataConnectionTrustedNetworks: []*net.IPNet{trustedCIDR},
+			},
+		},
+	}
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"))
+	assert.NoError(t, err) // trusted network
+
+	c.server.settings.DataConnectionTrustedNetworks = nil
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2")) // wrong ip
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "does not match control connection ip address")
+	}
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.1"))
+	assert.NoError(t, err)
+
+	// missing address in remote addr
+	c.conn = &testNetConn{
+		remoteAddr: &net.IPAddr{IP: net.ParseIP("192.168.1.1")},
+	}
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.2"))
+	assert.Error(t, err)
+
+	// nil remote address
+	c.conn = &testNetConn{}
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.1"))
+	assert.Error(t, err)
+
+	// invalid IP
+	c.conn = &testNetConn{
+		remoteAddr: &net.TCPAddr{IP: nil, Port: 21},
+	}
+
+	err = c.checkDataConnectionRequirement(net.ParseIP("2001:db8::69"))
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid remote IP")
+	}
+
+	// invalid setting
+	c.server.settings.DataConnectionCheck = 100
+	err = c.checkDataConnectionRequirement(net.ParseIP("192.168.1.1"))
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "unhandled data connection requirement")
+	}
+}*/

--- a/driver.go
+++ b/driver.go
@@ -185,6 +185,24 @@ const (
 	ImplicitEncryption
 )
 
+// DataConnectionRequirement is the enumerable that represents the supported
+// protection mode for data channels
+type DataConnectionRequirement int
+
+// Supported data connection requirements
+const (
+	// IPMatchRequired requires matching peer IP addresses of control and data connection
+	IPMatchRequired DataConnectionRequirement = iota
+	// IPMatchRelaxed requires matching peer IP addresses of control and data connection
+	// or the data connection IP address within the configured trusted networks, if any
+	IPMatchRelaxed
+	// IPMatchTrusted requires data connection IP address within the configured trusted
+	// networks
+	IPMatchTrusted
+	// IPMatchDisabled disables checking peer IP addresses of control and data connection
+	IPMatchDisabled
+)
+
 // Settings defines all the server settings
 // nolint: maligned
 type Settings struct {
@@ -209,4 +227,11 @@ type Settings struct {
 	DisableSYST              bool             // Disable SYST
 	EnableCOMB               bool             // Enable COMB support
 	DefaultTransferType      TransferType     // Transfer type to use if the client don't send the TYPE command
+	// ActiveConnectionsCheck defines the security requirements for active connections
+	ActiveConnectionsCheck DataConnectionRequirement
+	// PasvConnectionsCheck defines the security requirements for passive connections
+	PasvConnectionsCheck DataConnectionRequirement
+	// DataConnectionTrustedNetworks defines trusted networks for IPMatchRelaxed and
+	// IPMatchTrusted security requirements
+	DataConnectionTrustedNetworks []*net.IPNet
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -101,6 +102,7 @@ type TestServerDriver struct {
 	clientMU             sync.Mutex
 	Clients              []ClientContext
 	TLSVerificationReply tlsVerificationReply
+	errPassiveListener   error
 }
 
 // TestClientDriver defines a minimal serverftp client driver
@@ -324,6 +326,14 @@ func (driver *TestServerDriver) VerifyConnection(cc ClientContext, user string,
 	}
 
 	return nil, nil
+}
+
+func (driver *TestServerDriver) WrapPassiveListener(listener net.Listener) (net.Listener, error) {
+	if driver.errPassiveListener != nil {
+		return nil, driver.errPassiveListener
+	}
+
+	return listener, nil
 }
 
 // OpenFile opens a file in 3 possible modes: read, write, appending write (use appropriate flags)

--- a/transfer_active.go
+++ b/transfer_active.go
@@ -30,7 +30,17 @@ func (c *clientHandler) handlePORT(param string) error {
 	}
 
 	if err != nil {
-		c.writeMessage(StatusSyntaxErrorNotRecognised, fmt.Sprintf("Problem parsing %s: %v", param, err))
+		c.writeMessage(StatusSyntaxErrorParameters, fmt.Sprintf("Problem parsing %s: %v", param, err))
+
+		return nil
+	}
+
+	err = c.checkDataConnectionRequirement(raddr.IP, DataChannelActive)
+	if err != nil {
+		// we don't want to expose the full error to the client, we just log it
+		c.logger.Warn("Could not validate active data connection requirement", "err", err)
+		c.writeMessage(StatusSyntaxErrorParameters, "Your request does not meet "+
+			"the configured security requirements")
 
 		return nil
 	}

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -987,7 +987,7 @@ func TestPASVIPMatch(t *testing.T) {
 		if mode == IPMatchRequired {
 			require.Equal(t, "425 data connection security requirements not met", strings.TrimSpace(resp))
 		} else {
-			require.Equal(t, "150 Using transfer connection", strings.TrimSpace(resp))
+			require.True(t, strings.HasPrefix(resp, "150 Using transfer connection"))
 		}
 	}
 }

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -983,6 +983,7 @@ func TestPASVIPMatch(t *testing.T) {
 		require.NoError(t, err)
 
 		resp = string(buf[:n])
+
 		if mode == IPMatchRequired {
 			require.Equal(t, "425 data connection security requirements not met", strings.TrimSpace(resp))
 		} else {

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -839,7 +839,7 @@ func TestASCIITransfersInvalidFiles(t *testing.T) {
 func TestPASVWrappedListenerError(t *testing.T) {
 	s := NewTestServerWithDriver(t, &TestServerDriver{
 		Debug:              true,
-		errPassiveListener: net.ErrClosed,
+		errPassiveListener: os.ErrClosed,
 	})
 	conf := goftp.Config{
 		User:     authUser,

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -9,11 +9,15 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	lognoop "github.com/fclairamb/go-log/noop"
 	"github.com/secsy/goftp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -325,32 +329,41 @@ func TestBogusTransferStart(t *testing.T) {
 	{ // Completely bogus port declaration
 		status, resp, err := rc.SendCommand("PORT something")
 		require.NoError(t, err)
-		require.Equal(t, StatusSyntaxErrorNotRecognised, status, resp)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
 	}
 
 	{ // Completely bogus port declaration
 		status, resp, err := rc.SendCommand("EPRT something")
 		require.NoError(t, err)
-		require.Equal(t, StatusSyntaxErrorNotRecognised, status, resp)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
 	}
 
 	{ // Bad port number: 0
 		status, resp, err := rc.SendCommand("EPRT |2|::1|0|")
 		require.NoError(t, err)
-		require.Equal(t, StatusSyntaxErrorNotRecognised, status, resp)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
 	}
 
 	{ // Bad IP
 		status, resp, err := rc.SendCommand("EPRT |1|253.254.255.256|2000|")
 		require.NoError(t, err)
-		require.Equal(t, StatusSyntaxErrorNotRecognised, status, resp)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
 	}
 
 	{ // Bad protocol type: 3
 		status, resp, err := rc.SendCommand("EPRT |3|::1|2000|")
 		require.NoError(t, err)
-		require.Equal(t, StatusSyntaxErrorNotRecognised, status, resp)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
 	}
+
+	{ // good request but unacceptable ip address
+		status, resp, err := rc.SendCommand("EPRT |1|::1|2000|")
+		require.NoError(t, err)
+		require.Equal(t, StatusSyntaxErrorParameters, status, resp)
+		require.Contains(t, resp, "Your request does not meet the configured security requirements")
+	}
+
+	s.settings.ActiveConnectionsCheck = IPMatchDisabled
 
 	{ // We end-up on a positive note
 		status, resp, err := rc.SendCommand("EPRT |1|::1|2000|")
@@ -859,4 +872,161 @@ func TestPASVInvalidPublicHost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusServiceNotAvailable, rc)
 	require.Contains(t, resp, "invalid passive IP")
+}
+
+func TestPASVConnectionWait(t *testing.T) {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	require.NoError(t, err)
+
+	tcpListener, err := net.ListenTCP("tcp", addr)
+	require.NoError(t, err)
+
+	c := clientHandler{
+		conn: &testNetConn{
+			remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 21},
+		},
+		server: &FtpServer{
+			settings: &Settings{
+				PasvConnectionsCheck:   IPMatchRequired,
+				ActiveConnectionsCheck: IPMatchRequired,
+			},
+		},
+	}
+
+	p := passiveTransferHandler{
+		listener: &testNetListener{
+			conn: &testNetConn{
+				remoteAddr: &net.TCPAddr{IP: nil, Port: 21}, // invalid IP
+			},
+		},
+		tcpListener:   tcpListener,
+		Port:          tcpListener.Addr().(*net.TCPAddr).Port,
+		settings:      c.server.settings,
+		logger:        lognoop.NewNoOpLogger(),
+		checkDataConn: c.checkDataConnectionRequirement,
+	}
+
+	defer func() {
+		err = p.Close()
+		assert.NoError(t, err)
+	}()
+
+	_, err = p.ConnectionWait(1 * time.Second)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid remote IP")
+	}
+
+	p.listener = &testNetListener{
+		conn: &testNetConn{
+			remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 21},
+		},
+	}
+
+	_, err = p.ConnectionWait(1 * time.Second)
+	assert.NoError(t, err)
+}
+
+func TestPASVIPMatch(t *testing.T) {
+	s := NewTestServer(t, true)
+
+	conn, err := net.DialTimeout("tcp", s.Addr(), 5*time.Second)
+	require.NoError(t, err)
+
+	defer func() {
+		err = conn.Close()
+		require.NoError(t, err)
+	}()
+
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+
+	resp := string(buf[:n])
+	require.Equal(t, "220 TEST Server\r\n", resp)
+
+	loginConnection(t, conn)
+
+	for _, mode := range []DataConnectionRequirement{IPMatchRequired, IPMatchDisabled} {
+		s.settings.PasvConnectionsCheck = mode
+
+		_, err = conn.Write([]byte("PASV\r\n"))
+		require.NoError(t, err)
+
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+
+		resp := string(buf[:n])
+		port := getPortFromPASVResponse(t, resp)
+		assert.NotEqual(t, 0, port)
+
+		_, err = conn.Write([]byte("LIST\r\n"))
+		require.NoError(t, err)
+
+		addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+		// now dial from 127.0.1.1 instead of 127.0.0.1
+		d := net.Dialer{
+			LocalAddr: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.1.1"),
+				Port: 0,
+			},
+			Timeout: 5 * time.Second,
+		}
+		dataConn, err := d.Dial("tcp", addr)
+		require.NoError(t, err)
+
+		defer func() {
+			err = dataConn.Close()
+			assert.NoError(t, err)
+		}()
+
+		n, err = conn.Read(buf)
+		require.NoError(t, err)
+
+		resp = string(buf[:n])
+		if mode == IPMatchRequired {
+			require.Equal(t, "425 data connection security requirements not met", strings.TrimSpace(resp))
+		} else {
+			require.Equal(t, "150 Using transfer connection", strings.TrimSpace(resp))
+		}
+	}
+}
+
+func loginConnection(t *testing.T, conn net.Conn) {
+	buf := make([]byte, 1024)
+	_, err := conn.Write([]byte(fmt.Sprintf("USER %v\r\n", authUser)))
+	require.NoError(t, err)
+
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+
+	resp := string(buf[:n])
+	require.True(t, strings.HasPrefix(resp, "331"))
+
+	_, err = conn.Write([]byte(fmt.Sprintf("PASS %v\r\n", authPass)))
+	require.NoError(t, err)
+
+	n, err = conn.Read(buf)
+	require.NoError(t, err)
+
+	resp = string(buf[:n])
+	require.True(t, strings.HasPrefix(resp, "230"))
+}
+
+func getPortFromPASVResponse(t *testing.T, resp string) int {
+	port := 0
+	resp = strings.Replace(resp, "227 Entering Passive Mode", "", 1)
+	resp = strings.Replace(resp, "(", "", 1)
+	resp = strings.Replace(resp, ")", "", 1)
+	resp = strings.TrimSpace(resp)
+	respParts := strings.Split(resp, ",")
+	require.Len(t, respParts, 6)
+
+	for i, part := range respParts[4:6] {
+		portOctet, err := strconv.Atoi(part)
+		require.NoError(t, err)
+
+		port |= portOctet << (byte(1-i) * 8)
+	}
+
+	return port
 }


### PR DESCRIPTION
This patch improve security for passive connections and fixes bounce attacks for active ones.

`IPMatchRelaxed` and `IPMatchTrusted` are useful for passive connections if using haproxy. We can get rid of these settings if we expose a callback for the passive connection listener, so we can provide a custom listener that decodes the proxy header and get the real client IP as we do for the control connection. ProFTPD does not recommend to enable the proxy header for data connections and I followed the same recommendation for SFTPGo until now, no  problem to change if you prefer this way.

See the FAQ [here](https://htmlpreview.github.io/?https://github.com/Castaglia/proftpd-mod_proxy_protocol/blob/master/mod_proxy_protocol.html)