### PR TITLE
active mode data connection: fix bind: address already in use

### DIFF
--- a/control_fallback.go
+++ b/control_fallback.go
@@ -1,0 +1,14 @@
+//go:build !linux && !freebsd && !darwin && !aix && !dragonfly && !netbsd && !openbsd && !solaris && !windows
+// +build !linux,!freebsd,!darwin,!aix,!dragonfly,!netbsd,!openbsd,!solaris,!windows
+
+package ftpserver // nolint
+
+import (
+	"syscall"
+)
+
+// Control defines the function to use as dialer Control to reuse the same port/address.
+// This fallback implementation does nothing
+func Control(network, address string, c syscall.RawConn) error {
+	return nil
+}

--- a/control_unix.go
+++ b/control_unix.go
@@ -1,0 +1,32 @@
+//go:build linux || freebsd || darwin || aix || dragonfly || netbsd || openbsd || solaris
+// +build linux freebsd darwin aix dragonfly netbsd openbsd solaris
+
+package ftpserver // nolint
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Control defines the function to use as dialer Control to reuse the same port/address
+func Control(network, address string, c syscall.RawConn) error {
+	var errSetOpts error
+
+	err := c.Control(func(fd uintptr) {
+		errSetOpts = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if errSetOpts != nil {
+			return
+		}
+
+		errSetOpts = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		if errSetOpts != nil {
+			return
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	return errSetOpts
+}

--- a/control_windows.go
+++ b/control_windows.go
@@ -1,0 +1,21 @@
+package ftpserver // nolint
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// Control defines the function to use as dialer Control to reuse the same port/address
+func Control(network, address string, c syscall.RawConn) error {
+	var errSetOpts error
+
+	err := c.Control(func(fd uintptr) {
+		errSetOpts = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+	})
+	if err != nil {
+		return err
+	}
+
+	return errSetOpts
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
 )
 
 replace github.com/secsy/goftp => github.com/drakkan/goftp v0.0.0-20201220151643-27b7174e8caf

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fclairamb/go-log v0.0.0-20210725225107-80efc81cb386 h1:f/v/Fr+f7LiOKbMJlBuQPRmqrsYUXDzm1dpCJ29j9yo=
-github.com/fclairamb/go-log v0.0.0-20210725225107-80efc81cb386/go.mod h1:iqmym8aI6xBbZXnZSPjElrmQrlEwjwEemOmIzKaTBM8=
 github.com/fclairamb/go-log v0.1.0 h1:fNoqk8w62i4EDEuRzDgHdDVTqMYSyr3DS981R7F2x/Y=
 github.com/fclairamb/go-log v0.1.0/go.mod h1:iqmym8aI6xBbZXnZSPjElrmQrlEwjwEemOmIzKaTBM8=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
@@ -330,6 +328,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/transfer_active.go
+++ b/transfer_active.go
@@ -95,6 +95,7 @@ func (a *activeTransferHandler) Open() (net.Conn, error) {
 
 	if !a.settings.ActiveTransferPortNon20 {
 		dialer.LocalAddr, _ = net.ResolveTCPAddr("tcp", ":20")
+		dialer.Control = Control
 	}
 	// TODO(mgenov): support dialing with timeout
 	// Issues:

--- a/transfer_active.go
+++ b/transfer_active.go
@@ -138,7 +138,7 @@ var ErrRemoteAddrFormat = errors.New("remote address has a bad format")
 // Host: 192.168.150.80
 // Port: (14 * 256) + 148
 func parsePORTAddr(param string) (*net.TCPAddr, error) {
-	if !remoteAddrRegex.Match([]byte(param)) {
+	if !remoteAddrRegex.MatchString(param) {
 		return nil, fmt.Errorf("could not parse %s: %w", param, ErrRemoteAddrFormat)
 	}
 

--- a/transfer_active_test.go
+++ b/transfer_active_test.go
@@ -2,8 +2,12 @@
 package ftpserver
 
 import (
+	"net"
 	"regexp"
 	"testing"
+
+	"github.com/secsy/goftp"
+	"github.com/stretchr/testify/require"
 )
 
 func testRegexMatch(t *testing.T, regexp *regexp.Regexp, strings []string, expectedMatch bool) {
@@ -17,4 +21,38 @@ func testRegexMatch(t *testing.T, regexp *regexp.Regexp, strings []string, expec
 func TestRemoteAddrFormat(t *testing.T) {
 	testRegexMatch(t, remoteAddrRegex, []string{"1,2,3,4,5,6"}, true)
 	testRegexMatch(t, remoteAddrRegex, []string{"1,2,3,4,5"}, false)
+}
+
+func TestActiveTransferFromPort20(t *testing.T) {
+	listener, err := net.Listen("tcp", ":20") //nolint:gosec
+	if err != nil {
+		t.Skipf("Binding on port 20 is not supported here: %v", err)
+	}
+
+	err = listener.Close()
+	require.NoError(t, err)
+
+	server := NewTestServerWithDriver(t, &TestServerDriver{
+		Debug: true,
+		Settings: &Settings{
+			ActiveTransferPortNon20: false,
+		},
+	})
+
+	conf := goftp.Config{
+		User:            authUser,
+		Password:        authPass,
+		ActiveTransfers: true,
+	}
+	c, err := goftp.DialConfig(conf, server.Addr())
+	require.NoError(t, err, "Couldn't connect")
+
+	defer func() { panicOnError(c.Close()) }()
+
+	_, err = c.ReadDir("/")
+	require.NoError(t, err)
+
+	// the second ReadDir fails if we don't se the SO_REUSEPORT/SO_REUSEADDR socket options
+	_, err = c.ReadDir("/")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This patch set the socket option to reuse the same port, before the
patch, after connecting in active mode and setting ActiveTransferPortNon20
to false we had something like this:

```
ftp> ls
200 PORT command successful
425 could not establish active connection: dial tcp :20->127.0.0.1:36151: bind: address already in use
ftp> ls
200 PORT command successful
425 could not establish active connection: dial tcp :20->127.0.0.1:55911: bind: address already in use
```

More details [here](https://github.com/drakkan/sftpgo/discussions/260#discussioncomment-1575046)

@fclairamb please let me know what do you think about. There is no automated test for now, binding to port 20 requires root privileges, I'm not sure CI allows it. Also, adding a test that requires root access is annoying when running tests locally