### PR TITLE
parse public host while loading settings

### DIFF
--- a/server.go
+++ b/server.go
@@ -115,6 +115,20 @@ func (server *FtpServer) loadSettings() error {
 		return err
 	}
 
+	if s.PublicHost != "" {
+		parsedIP := net.ParseIP(s.PublicHost)
+		if parsedIP == nil {
+			return &ipValidationError{error: fmt.Sprintf("invalid passive IP %#v", s.PublicHost)}
+		}
+
+		parsedIP = parsedIP.To4()
+		if parsedIP == nil {
+			return &ipValidationError{error: fmt.Sprintf("invalid IPv4 passive IP %#v", s.PublicHost)}
+		}
+
+		s.PublicHost = parsedIP.String()
+	}
+
 	if s.Listener == nil && s.ListenAddr == "" {
 		s.ListenAddr = "0.0.0.0:2121"
 	}
@@ -275,10 +289,10 @@ func (server *FtpServer) clientArrival(conn net.Conn) {
 	c := server.newClientHandler(conn, id, server.settings.DefaultTransferType)
 	go c.HandleCommands()
 
-	c.logger.Info("Client connected", "clientIp", conn.RemoteAddr())
+	c.logger.Debug("Client connected", "clientIp", conn.RemoteAddr())
 }
 
 // clientDeparture
 func (server *FtpServer) clientDeparture(c *clientHandler) {
-	c.logger.Info("Client disconnected", "clientIp", c.conn.RemoteAddr())
+	c.logger.Debug("Client disconnected", "clientIp", c.conn.RemoteAddr())
 }

--- a/server_test.go
+++ b/server_test.go
@@ -134,3 +134,35 @@ func TestQuoteDoubling(t *testing.T) {
 		})
 	}
 }
+
+func TestServerSettings(t *testing.T) {
+	server := FtpServer{
+		Logger: lognoop.NewNoOpLogger(),
+		driver: &TestServerDriver{
+			Settings: &Settings{
+				PublicHost: "127.0.0",
+			},
+		},
+	}
+	err := server.loadSettings()
+	_, ok := err.(*ipValidationError)
+	require.True(t, ok)
+
+	server.driver = &TestServerDriver{
+		Settings: &Settings{
+			PublicHost: "::1",
+		},
+	}
+	err = server.loadSettings()
+	_, ok = err.(*ipValidationError)
+	require.True(t, ok)
+
+	server.driver = &TestServerDriver{
+		Settings: &Settings{
+			PublicHost: "::ffff:192.168.1.1",
+		},
+	}
+	err = server.loadSettings()
+	require.NoError(t, err)
+	require.Equal(t, "192.168.1.1", server.settings.PublicHost)
+}

--- a/transfer_pasv.go
+++ b/transfer_pasv.go
@@ -66,17 +66,14 @@ func (c *clientHandler) getCurrentIP() ([]string, error) {
 		}
 	}
 
-	parsedIP := net.ParseIP(ip)
-	if parsedIP == nil {
+	quads := strings.Split(ip, ".")
+	if len(quads) != 4 {
+		c.logger.Warn("Invalid passive IP", ip)
+
 		return nil, &ipValidationError{error: fmt.Sprintf("invalid passive IP %#v", ip)}
 	}
 
-	parsedIP = parsedIP.To4()
-	if parsedIP == nil {
-		return nil, &ipValidationError{error: fmt.Sprintf("invalid IPv4 passive IP %#v", ip)}
-	}
-
-	return strings.Split(parsedIP.String(), "."), nil
+	return quads, nil
 }
 
 // ErrNoAvailableListeningPort is returned when no port could be found to accept incoming connection


### PR DESCRIPTION
instead of parsing it every time we receive a PASV command.

Demoted some logs from info to debug.