### PR TITLE
Support IPv6 address for PublicHost when loading settings

### DIFF
--- a/server.go
+++ b/server.go
@@ -117,13 +117,8 @@ func (server *FtpServer) loadSettings() error {
 
 	if s.PublicHost != "" {
 		parsedIP := net.ParseIP(s.PublicHost)
-		if parsedIP == nil {
+		if parsedIP == nil || parsedIP.To4() == nil && parsedIP.To16() == nil {
 			return &ipValidationError{error: fmt.Sprintf("invalid passive IP %#v", s.PublicHost)}
-		}
-
-		parsedIP = parsedIP.To4()
-		if parsedIP == nil {
-			return &ipValidationError{error: fmt.Sprintf("invalid IPv4 passive IP %#v", s.PublicHost)}
 		}
 
 		s.PublicHost = parsedIP.String()


### PR DESCRIPTION
ftpserverlib (in general) supports listening on IPv6. However, at some point since 2020 the new check `parsedIP.To4()` broke the IPv6 support.
My proposed change explicitly validates `PublicHost` against both IPv4 and IPv6 addresses.

Related note: The test `TestServerSettings` does not make any sense (both before and after this PR). It checks against a valid IPv6 address (in this case `::1`) but expects an error. Obviously, checking against a valid IPv6 address should return no error. The fix for this test is either providing an invalid IPv6, or changing the expected value to no error.
https://github.com/fclairamb/ftpserverlib/blob/07db0255cfaa2dbc5a864dc6c6b21fcdffdff9ef/server_test.go#L151-L158