### PR TITLE
Use fallback control for Solaris / Illumos.

### DIFF
--- a/control_fallback.go
+++ b/control_fallback.go
@@ -1,5 +1,5 @@
 //go:build !linux && !freebsd && !darwin && !aix && !dragonfly && !netbsd && !openbsd && !windows
-// +build !linux,!freebsd,!darwin,!aix,!dragonfly,!netbsd,!openbsd,!windows solaris
+// +build !linux,!freebsd,!darwin,!aix,!dragonfly,!netbsd,!openbsd,!windows
 
 package ftpserver // nolint
 

--- a/control_fallback.go
+++ b/control_fallback.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !darwin && !aix && !dragonfly && !netbsd && !openbsd && !solaris && !windows
-// +build !linux,!freebsd,!darwin,!aix,!dragonfly,!netbsd,!openbsd,!solaris,!windows
+//go:build !linux && !freebsd && !darwin && !aix && !dragonfly && !netbsd && !openbsd && !windows
+// +build !linux,!freebsd,!darwin,!aix,!dragonfly,!netbsd,!openbsd,!windows solaris
 
 package ftpserver // nolint
 

--- a/control_unix.go
+++ b/control_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd || darwin || aix || dragonfly || netbsd || openbsd 
-// +build linux freebsd darwin aix dragonfly netbsd openbsd 
+//go:build linux || freebsd || darwin || aix || dragonfly || netbsd || openbsd
+// +build linux freebsd darwin aix dragonfly netbsd openbsd
 
 package ftpserver
 

--- a/control_unix.go
+++ b/control_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd || darwin || aix || dragonfly || netbsd || openbsd || solaris
-// +build linux freebsd darwin aix dragonfly netbsd openbsd solaris
+//go:build linux || freebsd || darwin || aix || dragonfly || netbsd || openbsd 
+// +build linux freebsd darwin aix dragonfly netbsd openbsd 
 
 package ftpserver
 


### PR DESCRIPTION
As an OS Illumos does support SO_REUSEPORT however Go thinks Solaris and Illumos do not [1]. Apparently someone did make an attempt to rectify this in Go but withdrew the patch [2]. This leads to a build error which this PR fixes.

For now for both Solaris and Illumos a workaround is to simply use the fallback control to avoid errors when compiling.

[1] https://go.googlesource.com/sys/+/refs/heads/master/unix/zerrors_solaris_amd64.go
[2] https://go-review.googlesource.com/c/sys/+/331989/1