### PR TITLE
Prefix MLST entries with a space

### DIFF
--- a/handle_dirs.go
+++ b/handle_dirs.go
@@ -285,14 +285,14 @@ func (c *clientHandler) dirTransferMLSD(w io.Writer, files []os.FileInfo) error 
 	}
 
 	for _, file := range files {
-		if err := c.writeMLSxOutput(w, file); err != nil {
+		if err := c.writeMLSxEntry(w, file); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (c *clientHandler) writeMLSxOutput(w io.Writer, file os.FileInfo) error {
+func (c *clientHandler) writeMLSxEntry(w io.Writer, file os.FileInfo) error {
 	var listType string
 	if file.IsDir() {
 		listType = "dir"

--- a/handle_files.go
+++ b/handle_files.go
@@ -466,21 +466,20 @@ func (c *clientHandler) handleMLST(param string) error {
 
 	path := c.absPath(param)
 
-	if info, err := c.driver.Stat(path); err == nil {
+	info, err := c.driver.Stat(path)
+	if err == nil {
 		defer c.multilineAnswer(StatusFileOK, "File details")()
 
 		// Each MLSx entry must start with a space when returned in a multiline answer
-		if errWrite := c.writer.WriteByte(' '); errWrite != nil {
-			return errWrite
-		}
-		if errWrite := c.writeMLSxOutput(c.writer, info); errWrite != nil {
-			return errWrite
+		if err = c.writer.WriteByte(' '); err == nil {
+			err = c.writeMLSxOutput(c.writer, info)
 		}
 	} else {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Could not list: %v", err))
+		err = nil
 	}
 
-	return nil
+	return err
 }
 
 func (c *clientHandler) handleALLO(param string) error {

--- a/handle_files.go
+++ b/handle_files.go
@@ -469,6 +469,10 @@ func (c *clientHandler) handleMLST(param string) error {
 	if info, err := c.driver.Stat(path); err == nil {
 		defer c.multilineAnswer(StatusFileOK, "File details")()
 
+		// Each MLSx entry must start with a space when returned in a multiline answer
+		if errWrite := c.writer.WriteByte(' '); errWrite != nil {
+			return errWrite
+		}
 		if errWrite := c.writeMLSxOutput(c.writer, info); errWrite != nil {
 			return errWrite
 		}

--- a/handle_files.go
+++ b/handle_files.go
@@ -472,7 +472,7 @@ func (c *clientHandler) handleMLST(param string) error {
 
 		// Each MLSx entry must start with a space when returned in a multiline answer
 		if err = c.writer.WriteByte(' '); err == nil {
-			err = c.writeMLSxOutput(c.writer, info)
+			err = c.writeMLSxEntry(c.writer, info)
 		}
 	} else {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Could not list: %v", err))


### PR DESCRIPTION
According to RFC 3659, an MLST response must prefix the entry lines with
a space, like so:

```
250-File details
 Type=file;Size=1024;Modify=20220813133357; 1
250 End
```

This commit adds the space and a test to validate that the MSLT response
is correct.

Signed-off-by: Thomas Hallgren <thomas@datawire.io>