### PR TITLE
Handle APPE when file does not yet exist

### DIFF
--- a/handle_files.go
+++ b/handle_files.go
@@ -54,7 +54,7 @@ func (c *clientHandler) transferFile(write bool, append bool, param, info string
 	if write {
 		fileFlag = os.O_WRONLY
 		if append {
-			fileFlag |= os.O_APPEND
+			fileFlag |= os.O_CREATE | os.O_APPEND
 			// ignore the seek position for append mode
 			c.ctxRest = 0
 		} else {


### PR DESCRIPTION
According to [the RFC](http://www.faqs.org/rfcs/rfc959.html), `APPE` should create a file if it does not yet exist.

> APPEND (with create) (APPE)
> This command causes the server-DTP to accept the data transferred via the data connection and to store the data in a file at the server site. If the file specified in the pathname exists at the server site, then the data shall be appended to that file; otherwise the file specified in the pathname shall be created at the server site.

We add a test case, see that it fails, then add the code change and see the test case succeed.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>