### PR TITLE
Allow specifying NON-PRINT format control

### DIFF
--- a/handle_misc.go
+++ b/handle_misc.go
@@ -262,7 +262,7 @@ func (c *clientHandler) handleTYPE(param string) error {
 	case "I", "L8":
 		c.currentTransferType = TransferTypeBinary
 		c.writeMessage(StatusOK, "Type set to binary")
-	case "A", "L7":
+	case "A", "AN", "L7":
 		c.currentTransferType = TransferTypeASCII
 		c.writeMessage(StatusOK, "Type set to ASCII")
 	default:

--- a/handle_misc_test.go
+++ b/handle_misc_test.go
@@ -297,6 +297,10 @@ func TestTYPE(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusOK, rc)
 
+	rc, _, err = raw.SendCommand("TYPE A N")
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, rc)
+
 	rc, _, err = raw.SendCommand("TYPE i")
 	require.NoError(t, err)
 	require.Equal(t, StatusOK, rc)


### PR DESCRIPTION
According to RFC 959 section 3.1.1.5.  Non-print format must be accepted by all FTP implementations. It's currently accepted if the format parameter is omitted as it is the default format control but if the second parameter is sent the current implementation breaks.