### PR TITLE
fix minio api not recognizing / as dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fclairamb/ftpserverlib
+module github.com/refuse2speak/ftpserverlib
 
 go 1.21
 

--- a/handle_dirs.go
+++ b/handle_dirs.go
@@ -62,7 +62,7 @@ func (c *clientHandler) handleCWD(param string) error {
 	pathAbsolute := c.absPath(param)
 
 	if stat, err := c.driver.Stat(pathAbsolute); err == nil {
-		if stat.IsDir() {
+		if stat.IsDir() || strings.HasSuffix(pathAbsolute, "/") {
 			c.SetPath(pathAbsolute)
 			c.writeMessage(StatusFileOK, "CD worked on "+pathAbsolute)
 		} else {
@@ -378,7 +378,7 @@ func (c *clientHandler) getFileList(param string, filePathAllowed bool) ([]os.Fi
 		return nil, "", newFileAccessError("couldn't stat", err)
 	}
 
-	if !info.IsDir() {
+	if !info.IsDir() && !strings.HasSuffix(listPath, "/") {
 		if filePathAllowed {
 			return []os.FileInfo{info}, path.Dir(c.getListPath()), nil
 		}


### PR DESCRIPTION
Minio does not recognize / root path as a directory, so ftpserverlib cannot return filelist of root directory. Fixing this as suggested by @cndonnie in https://github.com/fclairamb/ftpserver/issues/801.