### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -77,7 +77,6 @@ func getHashName(algo HASHAlgo) string {
 	return hashName
 }
 
-//nolint:maligned
 type clientHandler struct {
 	id                  uint32          // ID of the client
 	server              *FtpServer      // Server on which the connection was accepted

--- a/driver.go
+++ b/driver.go
@@ -257,8 +257,6 @@ const (
 )
 
 // Settings defines all the server settings
-//
-//nolint:maligned
 type Settings struct {
 	Listener                 net.Listener     // (Optional) To provide an already initialized listener
 	ListenAddr               string           // Listening address

--- a/driver_test.go
+++ b/driver_test.go
@@ -35,6 +35,8 @@ const (
 	authGroupID = 500
 )
 
+const nilUserPass = "nil"
+
 var errInvalidTLSCertificate = errors.New("invalid TLS certificate")
 
 // NewTestServer provides a test server with or without debugging
@@ -258,7 +260,7 @@ func (driver *TestServerDriver) AuthUser(_ ClientContext, user, pass string) (Cl
 		clientdriver := NewTestClientDriver(driver)
 
 		return clientdriver, nil
-	} else if user == "nil" && pass == "nil" {
+	} else if user == nilUserPass && pass == nilUserPass {
 		// Definitely a bad behavior (but can be done on the driver side)
 		return nil, nil //nolint:nilnil
 	}
@@ -490,7 +492,7 @@ func (driver *TestClientDriver) Symlink(oldname, newname string) error {
 
 // SITE command extension methods
 func (driver *TestClientDriver) SiteChmod(path string, mode os.FileMode) error {
-	return driver.Fs.Chmod(path, mode)
+	return driver.Chmod(path, mode)
 }
 
 func (driver *TestClientDriver) SiteChown(path string, uid, gid int) error {
@@ -506,11 +508,11 @@ func (driver *TestClientDriver) SiteChown(path string, uid, gid int) error {
 }
 
 func (driver *TestClientDriver) SiteMkdir(path string) error {
-	return driver.Fs.MkdirAll(path, 0o755)
+	return driver.MkdirAll(path, 0o755)
 }
 
 func (driver *TestClientDriver) SiteRmdir(path string) error {
-	return driver.Fs.RemoveAll(path)
+	return driver.RemoveAll(path)
 }
 
 // TestClientDriverNoSiteExt is a test driver that does NOT implement the SITE command extension
@@ -628,8 +630,9 @@ type TestServerDriverNoSiteExt struct {
 func (driver *TestServerDriverNoSiteExt) AuthUser(_ ClientContext, user, pass string) (ClientDriver, error) {
 	if user == authUser && pass == authPass {
 		clientdriver := NewTestClientDriverNoSiteExt(driver.TestServerDriver)
+
 		return clientdriver, nil
-	} else if user == "nil" && pass == "nil" {
+	} else if user == nilUserPass && pass == nilUserPass {
 		return nil, nil //nolint:nilnil
 	}
 

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -101,12 +101,14 @@ func (c *clientHandler) handleSiteCHMOD(params string) {
 	spl := strings.SplitN(params, " ", 2)
 	if len(spl) != 2 {
 		c.writeMessage(StatusSyntaxErrorParameters, "bad command")
+
 		return
 	}
 
 	modeNb, err := strconv.ParseUint(spl[0], 8, 32)
 	if err != nil {
 		c.writeMessage(StatusActionNotTaken, err.Error())
+
 		return
 	}
 
@@ -123,6 +125,7 @@ func (c *clientHandler) handleSiteCHMOD(params string) {
 
 	if err != nil {
 		c.writeMessage(StatusActionNotTaken, err.Error())
+
 		return
 	}
 
@@ -133,6 +136,7 @@ func (c *clientHandler) handleSiteCHOWN(params string) {
 	spl := strings.SplitN(params, " ", 3)
 	if len(spl) != 2 {
 		c.writeMessage(StatusSyntaxErrorParameters, "bad command")
+
 		return
 	}
 
@@ -170,6 +174,7 @@ func (c *clientHandler) handleSiteCHOWN(params string) {
 
 	if err != nil {
 		c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Couldn't chown: %v", err))
+
 		return
 	}
 
@@ -179,6 +184,7 @@ func (c *clientHandler) handleSiteCHOWN(params string) {
 func (c *clientHandler) handleSiteMKDIR(params string) {
 	if params == "" {
 		c.writeMessage(StatusSyntaxErrorNotRecognised, "Missing path")
+
 		return
 	}
 
@@ -189,12 +195,14 @@ func (c *clientHandler) handleSiteMKDIR(params string) {
 		err := siteExt.SiteMkdir(path)
 		if err != nil {
 			c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Couldn't create dir %s: %v", path, err))
+
 			return
 		}
 	} else {
 		// Fallback to default implementation
 		if err := c.driver.MkdirAll(path, 0o755); err != nil {
 			c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Couldn't create dir %s: %v", path, err))
+
 			return
 		}
 	}
@@ -205,6 +213,7 @@ func (c *clientHandler) handleSiteMKDIR(params string) {
 func (c *clientHandler) handleSiteRMDIR(params string) {
 	if params == "" {
 		c.writeMessage(StatusSyntaxErrorNotRecognised, "Missing path")
+
 		return
 	}
 
@@ -215,12 +224,14 @@ func (c *clientHandler) handleSiteRMDIR(params string) {
 		err := siteExt.SiteRmdir(path)
 		if err != nil {
 			c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Couldn't remove dir %s: %v", path, err))
+
 			return
 		}
 	} else {
 		// Fallback to default implementation
 		if err := c.driver.RemoveAll(path); err != nil {
 			c.writeMessage(StatusActionNotTaken, fmt.Sprintf("Couldn't remove dir %s: %v", path, err))
+
 			return
 		}
 	}

--- a/handle_misc_test.go
+++ b/handle_misc_test.go
@@ -370,53 +370,25 @@ func TestQuitWithTransferInProgress(t *testing.T) {
 }
 
 func TestTYPE(t *testing.T) {
-	server := NewTestServer(t, false)
-	conf := goftp.Config{
-		User:     authUser,
-		Password: authPass,
+	raw := newClientWithRawConn(t)
+
+	cases := []struct {
+		cmd    string
+		expect int
+	}{
+		{"TYPE I", StatusOK},
+		{"TYPE A", StatusOK},
+		{"TYPE A N", StatusOK},
+		{"TYPE i", StatusOK},
+		{"TYPE a", StatusOK},
+		{"TYPE l 8", StatusOK},
+		{"TYPE l 7", StatusOK},
+		{"TYPE wrong", StatusNotImplementedParam},
 	}
 
-	client, err := goftp.DialConfig(conf, server.Addr())
-	require.NoError(t, err, "Couldn't connect")
-
-	defer func() { panicOnError(client.Close()) }()
-
-	raw, err := client.OpenRawConn()
-	require.NoError(t, err, "Couldn't open raw connection")
-
-	defer func() { require.NoError(t, raw.Close()) }()
-
-	returnCode, _, err := raw.SendCommand("TYPE I")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE A")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE A N")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE i")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE a")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE l 8")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE l 7")
-	require.NoError(t, err)
-	require.Equal(t, StatusOK, returnCode)
-
-	returnCode, _, err = raw.SendCommand("TYPE wrong")
-	require.NoError(t, err)
-	require.Equal(t, StatusNotImplementedParam, returnCode)
+	for _, c := range cases {
+		sendAndCheck(t, raw, c.cmd, c.expect)
+	}
 }
 
 func TestMode(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,40 @@
+package ftpserver
+
+import (
+	"testing"
+
+	"github.com/secsy/goftp"
+	"github.com/stretchr/testify/require"
+)
+
+// newClientWithRawConn creates a test server and returns a connected client and
+// raw connection. The resources are closed automatically when the test ends.
+func newClientWithRawConn(t *testing.T) goftp.RawConn {
+	t.Helper()
+
+	server := NewTestServer(t, false)
+	conf := goftp.Config{
+		User:     authUser,
+		Password: authPass,
+	}
+
+	client, err := goftp.DialConfig(conf, server.Addr())
+	require.NoError(t, err, "Couldn't connect")
+
+	t.Cleanup(func() { panicOnError(client.Close()) })
+
+	raw, err := client.OpenRawConn()
+	require.NoError(t, err, "Couldn't open raw connection")
+
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+
+	return raw
+}
+
+func sendAndCheck(t *testing.T, raw goftp.RawConn, cmd string, expected int) {
+	t.Helper()
+
+	code, _, err := raw.SendCommand(cmd)
+	require.NoError(t, err)
+	require.Equal(t, expected, code)
+}


### PR DESCRIPTION
## Summary
- add helper for connecting and executing commands in tests
- deduplicate tests using helper and loops
- fix staticcheck and nlreturn warnings
- remove obsolete nolint directives

## Testing
- `golangci-lint run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846b8edf82c832b970e78a930a3f4db