### PR TITLE
Getciphersuite function in client handler

### DIFF
--- a/client_handler.go
+++ b/client_handler.go
@@ -52,6 +52,7 @@ var (
 	errNoTransferConnection  = errors.New("unable to open transfer: no transfer connection")
 	errTLSRequired           = errors.New("unable to open transfer: TLS is required")
 	errInvalidTLSRequirement = errors.New("invalid TLS requirement")
+	errNonTLSConnection      = errors.New("GetTLSCiphersuite called on a nonTLS connection")
 )
 
 func getHashMapping() map[string]HASHAlgo {
@@ -264,8 +265,9 @@ func (c *clientHandler) GetTLSCipherSuite() (uint16, error) {
 	conn := c.conn
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {
-		return 0, errors.New("GetTLSCiphersuite called on a nonTLS connection")
+		return 0, errNonTLSConnection
 	}
+
 	return tlsConn.ConnectionState().CipherSuite, nil
 }
 

--- a/client_handler.go
+++ b/client_handler.go
@@ -260,7 +260,7 @@ func (c *clientHandler) HasTLSForTransfers() bool {
 	return c.transferTLS
 }
 
-func (c *clientHandler) GetTLSCiphersuite() (uint16, error) {
+func (c *clientHandler) GetTLSCipherSuite() (uint16, error) {
 	conn := c.conn
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {

--- a/client_handler.go
+++ b/client_handler.go
@@ -2,6 +2,7 @@ package ftpserver
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -257,6 +258,15 @@ func (c *clientHandler) HasTLSForTransfers() bool {
 	defer c.paramsMutex.RUnlock()
 
 	return c.transferTLS
+}
+
+func (c *clientHandler) GetTLSCiphersuite() (uint16, error) {
+	conn := c.conn
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return 0, errors.New("GetTLSCiphersuite called on a nonTLS connection")
+	}
+	return tlsConn.ConnectionState().CipherSuite, nil
 }
 
 func (c *clientHandler) SetExtra(extra any) {

--- a/driver.go
+++ b/driver.go
@@ -189,7 +189,7 @@ type ClientContext interface {
 	HasTLSForTransfers() bool
 
 	// GetTlSCipherSuite returns ID
-	GetTlSCipherSuite() (uint16, error)
+	GetTLSCipherSuite() (uint16, error)
 
 	// GetLastCommand returns the last received command
 	GetLastCommand() string

--- a/driver.go
+++ b/driver.go
@@ -188,6 +188,9 @@ type ClientContext interface {
 	// HasTLSForTransfers returns true if the transfer connection is over TLS
 	HasTLSForTransfers() bool
 
+	// GetTlSCipherSuite returns ID
+	GetTlSCipherSuite() (uint16, error)
+
 	// GetLastCommand returns the last received command
 	GetLastCommand() string
 


### PR DESCRIPTION
Implements a GetTLSCipherSuite function in order to know the ciphersuite used by the underlying net.conn if possible. Useful in order to track usage and notice users of deprecation of cipher suites. The other solution I found was giving access to the net.Conn object. Since it is implemented here it doesn't require any changes on users of the library