### PR TITLE
chore: add semantic-pr and release-please workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: googleapis/release-please-action@v4.4.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,32 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            auth
+            deps
+            docs
+            transfer
+            tls
+            driver
+            server
+            config
+            release
+          requireScope: false

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you're interested in a fully featured FTP server, you should use [sftpgo](htt
    * [HASH](https://tools.ietf.org/html/draft-bryan-ftpext-hash-02) - Hashing of files
    * [AVBL](https://tools.ietf.org/html/draft-peterson-streamlined-ftp-command-extensions-10#section-4) - Available space
    * [COMB](https://help.globalscape.com/help/archive/eft6-4/mergedprojects/eft/allowingmultiparttransferscomb_command.htm) - Combine files
+   * [MODE Z](https://datatracker.ietf.org/doc/html/draft-preston-ftpext-deflate-04) - Transfer compression (deflate)
 
 ## Quick test
 The easiest way to test this library is to use [ftpserver](https://github.com/fclairamb/ftpserver).


### PR DESCRIPTION
## Summary

- Add semantic-pr workflow to validate PR titles follow conventional commit format
- Add release-please workflow for automated release management
- Update README.md to document MODE Z transfer compression support (newly added in #461)

## Changes

### New GitHub Actions Workflows

**semantic-pr.yml**: Validates that PR titles follow [conventional commits](https://www.conventionalcommits.org/) format. Supported scopes include `auth`, `deps`, `docs`, `transfer`, `tls`, `driver`, `server`, `config`, and `release`.

**release-please.yml**: Automates release management using [release-please](https://github.com/googleapis/release-please). When conventional commits are merged to main, it automatically creates/updates a release PR with changelog.

### README Update

Added MODE Z (transfer compression) to the list of supported extensions, linking to the [draft-preston-ftpext-deflate-04](https://datatracker.ietf.org/doc/html/draft-preston-ftpext-deflate-04) specification.

## Test plan

- [ ] Verify semantic-pr workflow runs on PR creation
- [ ] Verify release-please creates a release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)