### PR TITLE
feat: make MODE Z configurable

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -323,7 +323,7 @@ type Settings struct {
 	DisableSTAT              bool             // Disable Server STATUS, STAT on files and directories will still work
 	DisableSYST              bool             // Disable SYST
 	EnableCOMB               bool             // Enable COMB support
-	DeflateCompressionLevel  int              // Deflate compression level (1-9)
+	DeflateCompressionLevel  int              // Deflate compression level (0-9). 0 means disabled
 	DefaultTransferType      TransferType     // Transfer type to use if the client don't send the TYPE command
 	// ActiveConnectionsCheck defines the security requirements for active connections
 	ActiveConnectionsCheck DataConnectionRequirement

--- a/handle_misc.go
+++ b/handle_misc.go
@@ -222,9 +222,12 @@ func (c *clientHandler) handleFEAT(_ string) error {
 		"SIZE",
 		"MDTM",
 		"REST STREAM",
-		"MODE Z",
 		"EPRT",
 		"EPSV",
+	}
+
+	if c.server.settings.DeflateCompressionLevel > 0 {
+		features = append(features, "MODE Z")
 	}
 
 	if !c.server.settings.DisableMLSD {
@@ -301,8 +304,12 @@ func (c *clientHandler) handleMODE(param string) error {
 		c.transferMode = TransferModeStream
 		c.writeMessage(StatusOK, "Using stream mode")
 	case "Z":
-		c.transferMode = TransferModeDeflate
-		c.writeMessage(StatusOK, "Using deflate mode")
+		if c.server.settings.DeflateCompressionLevel > 0 {
+			c.transferMode = TransferModeDeflate
+			c.writeMessage(StatusOK, "Using deflate mode")
+		} else {
+			c.writeMessage(StatusNotImplementedParam, "Unimplemented MODE type")
+		}
 	default:
 		c.writeMessage(StatusNotImplementedParam, "Unsupported mode")
 	}

--- a/handle_misc_test.go
+++ b/handle_misc_test.go
@@ -438,6 +438,10 @@ func TestMode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusOK, returnCode)
 
+	returnCode, _, err = raw.SendCommand("MODE Z") // Disabled by default
+	require.NoError(t, err)
+	require.Equal(t, StatusNotImplementedParam, returnCode)
+
 	returnCode, _, err = raw.SendCommand("MODE X")
 	require.NoError(t, err)
 	require.Equal(t, StatusNotImplementedParam, returnCode)

--- a/server.go
+++ b/server.go
@@ -164,10 +164,6 @@ func (server *FtpServer) loadSettings() error {
 		settings.Banner = "ftpserver - golang FTP server"
 	}
 
-	if settings.DeflateCompressionLevel == 0 {
-		settings.DeflateCompressionLevel = 5
-	}
-
 	server.settings = settings
 
 	return nil

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -1413,7 +1413,11 @@ func getPortFromEPSVResponse(t *testing.T, resp string) int {
 }
 
 func TestTransferModeDeflate(t *testing.T) {
-	driver := &TestServerDriver{Debug: true}
+	settings := &Settings{
+		DeflateCompressionLevel: 5,
+		DefaultTransferType:     TransferTypeBinary,
+	}
+	driver := &TestServerDriver{Debug: true, Settings: settings}
 	server := NewTestServerWithTestDriver(t, driver)
 
 	conf := goftp.Config{User: authUser, Password: authPass}


### PR DESCRIPTION
This is a non-standard FTP extension and is not supported by major clients:

https://trac.filezilla-project.org/ticket/2977
https://winscp.net/forum/viewtopic.php?t=25351

Additionally, it could potentially increase the attack surface, although I have not been able to fully verify this:

```
$ lftp ftp://127.0.0.1:2121
lftp 127.0.0.1:~> debug on;
lftp 127.0.0.1:~> set ftp:use-mode-z yes;
lftp 127.0.0.1:~> login a password
lftp a@127.0.0.1:~> ls
**** zlib inflate error: incorrect header check
ls: Errore fatale: zlib inflate error: incorrect header check
lftp a@127.0.0.1:/> quit
```

Do you know of any compatible client? Which client has it been tested with?