### PR TITLE
docs: mention REST in DisableASCIIConversion documentation

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -365,8 +365,8 @@ type Settings struct {
 	DeflateCompressionLevel int          // Deflate compression level (0-9). 0 means disabled
 	DefaultTransferType     TransferType // Transfer type to use if the client don't send the TYPE command
 	// DisableASCIIConversion disables CRLF/LF line-ending conversion for TYPE A (ASCII) transfers.
-	// When true, files are transferred byte-for-byte even in ASCII mode, and SIZE is allowed in
-	// ASCII mode. This is not RFC 959-compliant but matches the behavior of vsftpd's
+	// When true, files are transferred byte-for-byte even in ASCII mode, and SIZE and REST are
+	// allowed in ASCII mode. This is not RFC 959-compliant but matches the behavior of vsftpd's
 	// ascii_download_enable/ascii_upload_enable=NO and is useful when clients do not want the
 	// server to modify their files.
 	DisableASCIIConversion bool


### PR DESCRIPTION
Follow-up to #660, which made `handleREST` honor `DisableASCIIConversion` the same way `handleSIZE` already did. The `Settings.DisableASCIIConversion` comment only mentioned SIZE.

Comment-only change, no behavior change.